### PR TITLE
Update style of TensorAutoregressions package

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,9 +11,11 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+StatsAPI = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 TensorToolbox = "9c690861-8ade-587a-897e-15364bc6f718"
 
 [compat]
+StatsAPI = "1.7.0"
 julia = "1.8"
 
 [extras]

--- a/src/TensorAutoregressions.jl
+++ b/src/TensorAutoregressions.jl
@@ -21,8 +21,12 @@ using
     CairoMakie,
     Dates
 
+using StatsAPI: StatisticalModel 
+using StatsAPI: aic, aicc, bic
+
 import LinearAlgebra: rank
 import Statistics: cov
+import StatsAPI: fit!, loglikelihood, dof, nobs
 
 # Makie backend and theme
 CairoMakie.activate!()
@@ -42,6 +46,8 @@ export
 
     ## fit
     fit!,
+    loglikelihood,
+    dof, nobs, aic, aicc, bic,
 
     ## forecast
     forecast,

--- a/src/TensorAutoregressions.jl
+++ b/src/TensorAutoregressions.jl
@@ -39,7 +39,7 @@ export
 
 ## fit
       fit!,
-      loglikelihood,
+      rss, loglikelihood,
       dof, nobs, aic, aicc, bic,
 
 ## forecast

--- a/src/TensorAutoregressions.jl
+++ b/src/TensorAutoregressions.jl
@@ -19,7 +19,7 @@ using StatsAPI: aic, aicc, bic
 
 import LinearAlgebra: rank
 import Statistics: cov
-import StatsAPI: fit!, loglikelihood, dof, nobs
+import StatsAPI: fit!, rss, loglikelihood, dof, nobs
 
 # Makie backend and theme
 CairoMakie.activate!()

--- a/src/TensorAutoregressions.jl
+++ b/src/TensorAutoregressions.jl
@@ -1,8 +1,8 @@
 #=
 TensorAutoregressions.jl
 
-    Provides a collection of tools for working with tensor autoregressive 
-    models, such as estimation, forecasting, and impulse response analysis. 
+    Provides a collection of tools for working with tensor autoregressive models, such as
+    estimation, forecasting, and impulse response analysis.
 
 @author: Quint Wiersma <q.wiersma@vu.nl>
 
@@ -11,17 +11,10 @@ TensorAutoregressions.jl
 
 module TensorAutoregressions
 
-using 
-    LinearAlgebra,
-    Statistics, 
-    Random, 
-    Distributions, 
-    TensorToolbox, 
-    Optim, 
-    CairoMakie,
-    Dates
+using LinearAlgebra, Statistics, Random, Distributions, TensorToolbox, Optim
+using CairoMakie, Dates
 
-using StatsAPI: StatisticalModel 
+using StatsAPI: StatisticalModel
 using StatsAPI: aic, aicc, bic
 
 import LinearAlgebra: rank
@@ -32,35 +25,35 @@ import StatsAPI: fit!, loglikelihood, dof, nobs
 CairoMakie.activate!()
 
 export
-    # constructor
-    TensorAutoregression,
+# constructor
+      TensorAutoregression,
 
-    # interface methods
-    ## getters
-    data, coef, dist,   # general
-    resid, cov, # residuals
-    factors, loadings, rank, intercept, dynamics, # Kruskal coefficient tensor
+# interface methods
+## getters
+      data, coef, dist,   # general
+      resid, cov, # residuals
+      factors, loadings, rank, intercept, dynamics, # Kruskal coefficient tensor
 
-    # simulate
-    simulate,
+# simulate
+      simulate,
 
-    ## fit
-    fit!,
-    loglikelihood,
-    dof, nobs, aic, aicc, bic,
+## fit
+      fit!,
+      loglikelihood,
+      dof, nobs, aic, aicc, bic,
 
-    ## forecast
-    forecast,
+## forecast
+      forecast,
 
-    ## impulse response functions
-    irf,
-    lower, upper, orth,
+## impulse response functions
+      irf,
+      lower, upper, orth,
 
-    # plotting
-    data_plot,
-    kruskal_plot,
-    cov_plot,
-    irf_plot
+# plotting
+      data_plot,
+      kruskal_plot,
+      cov_plot,
+      irf_plot
 
 include("tensor_algebra.jl")
 include("types.jl")

--- a/src/fit/solver.jl
+++ b/src/fit/solver.jl
@@ -1,9 +1,9 @@
 #=
 solver.jl
 
-    Provides alternating least squares (ALS) and expectation-maximization (EM)
-    optimization routines for fitting a tensor autoregressive model with Kruskal
-    coefficient tensor and tensor error distribution.
+    Provides alternating least squares (ALS) and expectation-maximization (EM) optimization
+    routines for fitting a tensor autoregressive model with Kruskal coefficient tensor and
+    tensor error distribution.
 
 @author: Quint Wiersma <q.wiersma@vu.nl>
 
@@ -13,9 +13,8 @@ solver.jl
 """
     update!(model)
 
-Update parameters of tensor autoregression `model` using an alternating least
-squares (ALS) solve. Wrapper to invoke multiple dispatch over static and dynamic
-tensor autoregressions.
+Update parameters of tensor autoregression `model` using an alternating least squares (ALS)
+solve. Wrapper to invoke multiple dispatch over static and dynamic tensor autoregressions.
 """
 update!(model::StaticTensorAutoregression) = als!(coef(model), dist(model), data(model))
 function update!(model::DynamicTensorAutoregression)
@@ -34,9 +33,9 @@ end
 """
     als!(A, ε, y[, V])
 
-Update Kruskal coefficient tensor `A` and tensor error distribution `ε` for the
-tensor autoregressive model based on data `y` and smoothed loading variance `V`
-when `A` is dynamic using an alternating least squares (ALS) solve.
+Update Kruskal coefficient tensor `A` and tensor error distribution `ε` for the tensor
+autoregressive model based on data `y` and smoothed loading variance `V` when `A` is dynamic
+using an alternating least squares (ALS) solve.
 """
 function als!(A::StaticKruskal, ε::WhiteNoise, y::AbstractArray)
     dims = size(y)
@@ -74,14 +73,10 @@ function als!(A::StaticKruskal, ε::WhiteNoise, y::AbstractArray)
             M = Zkr * Xkr'
 
             # update factor k
-            update_factor!(factors(A)[k][:, r],
-                           factors(A)[k + n][:, r],
-                           G \ M',
+            update_factor!(factors(A)[k][:, r], factors(A)[k + n][:, r], G \ M',
                            inv(loadings(A)[r]))
             # update factor k+n
-            update_factor!(factors(A)[k + n][:, r],
-                           factors(A)[k][:, r],
-                           M,
+            update_factor!(factors(A)[k + n][:, r], factors(A)[k][:, r], M,
                            inv(loadings(A)[r] *
                                dot(factors(A)[k][:, r], G, factors(A)[k][:, r])))
 
@@ -105,7 +100,6 @@ function als!(A::StaticKruskal, ε::WhiteNoise, y::AbstractArray)
 
     return nothing
 end
-
 function als!(A::StaticKruskal, ε::TensorNormal, y::AbstractArray)
     dims = size(y)
     n = ndims(y) - 1
@@ -153,15 +147,11 @@ function als!(A::StaticKruskal, ε::TensorNormal, y::AbstractArray)
             M = Zkr * Xkr'
 
             # update factor k
-            update_factor!(factors(A)[k][:, r],
-                           factors(A)[k + n][:, r],
-                           G \ M' * Ω[k],
+            update_factor!(factors(A)[k][:, r], factors(A)[k + n][:, r], G \ M' * Ω[k],
                            inv(loadings(A)[r] *
                                dot(factors(A)[k + n][:, r], Ω[k], factors(A)[k + n][:, r])))
             # update factor k+n
-            update_factor!(factors(A)[k + n][:, r],
-                           factors(A)[k][:, r],
-                           M,
+            update_factor!(factors(A)[k + n][:, r], factors(A)[k][:, r], M,
                            inv(loadings(A)[r] *
                                dot(factors(A)[k][:, r], G, factors(A)[k][:, r])))
 
@@ -197,11 +187,7 @@ function als!(A::StaticKruskal, ε::TensorNormal, y::AbstractArray)
 
     return nothing
 end
-
-function als!(A::DynamicKruskal,
-              ε::TensorNormal,
-              y::AbstractArray,
-              V::AbstractVector)
+function als!(A::DynamicKruskal, ε::TensorNormal, y::AbstractArray, V::AbstractVector)
     dims = size(y)
     n = ndims(y) - 1
 
@@ -274,14 +260,10 @@ function als!(A::DynamicKruskal,
             M = Zkr * Xkr'
 
             # update factor k
-            update_factor!(factors(A)[k][:, r],
-                           factors(A)[k + n][:, r],
-                           G \ M' * Ω[k],
+            update_factor!(factors(A)[k][:, r], factors(A)[k + n][:, r], G \ M' * Ω[k],
                            inv(dot(factors(A)[k + n][:, r], Ω[k], factors(A)[k + n][:, r])))
             # update factor k+n
-            update_factor!(factors(A)[k + n][:, r],
-                           factors(A)[k][:, r],
-                           M,
+            update_factor!(factors(A)[k + n][:, r], factors(A)[k][:, r], M,
                            inv(dot(factors(A)[k][:, r], G, factors(A)[k][:, r])))
 
             # update outer product of Kruskal factors
@@ -338,12 +320,10 @@ end
 """
     update_transition!(A, V, Γ)
 
-Update transition dynamics of dynamic Kruskal coefficient tensor `A` using
-smoothed loadings variance `V`, and autocovariance `Γ`.
+Update transition dynamics of dynamic Kruskal coefficient tensor `A` using smoothed loadings
+variance `V`, and autocovariance `Γ`.
 """
-function update_transition!(A::DynamicKruskal,
-                            V::AbstractVector,
-                            Γ::AbstractVector)
+function update_transition!(A::DynamicKruskal, V::AbstractVector, Γ::AbstractVector)
     T = length(V)
 
     # objective closures

--- a/src/fit/solver.jl
+++ b/src/fit/solver.jl
@@ -393,7 +393,7 @@ function update_transition!(
     function f_intercept(x, r)
         f = zero(x)
         for t = 2:T
-           f -= 2 * (loadings(A)[r,t] - dynamics(A)[r,r] * loadings(A)[r,t-1]) * x
+           f -= 2 * (loadings(A)[r,t] - dynamics(A).diag[r] * loadings(A)[r,t-1]) * x
         end
         f = x^2 + f / (T - 1)
 
@@ -418,17 +418,17 @@ function update_transition!(
         for r = 1:rank(A)
             objective(x) = f_dynamics(x, r)
             res = optimize(f_dynamics, 0.0, 1.0)
-            dynamics(A)[r,r] = Optim.minimizer(res)
+            dynamics(A).diag[r] = Optim.minimizer(res)
         end
     end
     if !haskey(fixed, :intercept)
         for r = 1:rank(A)
             objective(x) = f_intercept(x, r)
-            res = optimize(f_intercept, 0.0, 0.7 * (1 - dynamics(A)[r,r]))
+            res = optimize(f_intercept, 0.0, 0.7 * (1 - dynamics(A).diag[r]))
             intercept(A)[r] = Optim.minimizer(res)
         end
     end
-    cov(A).data .= I - dynamics(A) * dynamics(A)'
+    cov(A) .= I - dynamics(A) * dynamics(A)'
 
     return nothing
 end

--- a/src/fit/solver.jl
+++ b/src/fit/solver.jl
@@ -1,9 +1,9 @@
 #=
 solver.jl
 
-    Provides alternating least squares (ALS) and expectation-maximization (EM) 
-    optimization routines for fitting a tensor autoregressive model with Kruskal 
-    coefficient tensor and tensor error distribution. 
+    Provides alternating least squares (ALS) and expectation-maximization (EM)
+    optimization routines for fitting a tensor autoregressive model with Kruskal
+    coefficient tensor and tensor error distribution.
 
 @author: Quint Wiersma <q.wiersma@vu.nl>
 
@@ -43,7 +43,7 @@ function als!(A::StaticKruskal, ε::WhiteNoise, y::AbstractArray)
     n = ndims(y) - 1
 
     # outer product of Kruskal factors
-    U = [[factors(A)[i + n][:, r] * factors(A)[i][:, r]' for i in 1:n] for r in 1:rank(A)]
+    U = outer(A)
 
     # lag and lead variables
     y_lead = selectdim(y, n + 1, 2:last(dims))
@@ -118,7 +118,7 @@ function als!(A::StaticKruskal, ε::TensorNormal, y::AbstractArray)
     Ω = transpose.(Cinv) .* Cinv
 
     # outer product of Kruskal factors
-    U = [[factors(A)[i + n][:, r] * factors(A)[i][:, r]' for i in 1:n] for r in 1:rank(A)]
+    U = outer(A)
 
     # scaling
     S = [[Cinv[i] * U[r][i] for i in 1:n] for r in 1:rank(A)]
@@ -213,7 +213,7 @@ function als!(A::DynamicKruskal,
     Ω = transpose.(Cinv) .* Cinv
 
     # outer product of Kruskal factors
-    U = [[factors(A)[i + n][:, r] * factors(A)[i][:, r]' for i in 1:n] for r in 1:rank(A)]
+    U = outer(A)
 
     # lag and lead variables
     y_lead = selectdim(y, n + 1, 2:last(dims))

--- a/src/fit/solver.jl
+++ b/src/fit/solver.jl
@@ -43,16 +43,16 @@ function als!(A::StaticKruskal, ε::WhiteNoise, y::AbstractArray)
     n = ndims(y) - 1
 
     # outer product of Kruskal factors
-    U = [[factors(A)[i+n][:,r] * factors(A)[i][:,r]' for i = 1:n] for r = 1:rank(A)]
+    U = [[factors(A)[i + n][:, r] * factors(A)[i][:, r]' for i in 1:n] for r in 1:rank(A)]
 
     # lag and lead variables
-    y_lead = selectdim(y, n+1, 2:last(dims))
-    y_lag = selectdim(y, n+1, 1:last(dims)-1)
+    y_lead = selectdim(y, n + 1, 2:last(dims))
+    y_lag = selectdim(y, n + 1, 1:(last(dims) - 1))
 
     # initialize residuals
     resid(ε) .= y_lead
 
-    for r = 1:rank(A)
+    for r in 1:rank(A)
         s = setdiff(1:rank(A), r)
         # dependent variable tensor
         Zr = copy(y_lead)
@@ -60,10 +60,10 @@ function als!(A::StaticKruskal, ε::WhiteNoise, y::AbstractArray)
             Xi = tucker(y_lag, U[i])
             Zr .-= loadings(A)[i] .* Xi
         end
-        for k = 1:n
+        for k in 1:n
             m = setdiff(1:n, k)
             # matricize dependent variable along k-th mode
-            Zkr = matricize(Zr, k) 
+            Zkr = matricize(Zr, k)
             # matricize regressor along k-th mode
             Xr = tucker(y_lag, U[r][m], m)
             Xkr = matricize(Xr, k)
@@ -74,22 +74,19 @@ function als!(A::StaticKruskal, ε::WhiteNoise, y::AbstractArray)
             M = Zkr * Xkr'
 
             # update factor k
-            update_factor!(
-                factors(A)[k][:,r], 
-                factors(A)[k+n][:,r], 
-                G \ M', 
-                inv(loadings(A)[r])
-            )
+            update_factor!(factors(A)[k][:, r],
+                           factors(A)[k + n][:, r],
+                           G \ M',
+                           inv(loadings(A)[r]))
             # update factor k+n
-            update_factor!(
-                factors(A)[k+n][:,r], 
-                factors(A)[k][:,r], 
-                M, 
-                inv(loadings(A)[r] * dot(factors(A)[k][:,r], G, factors(A)[k][:,r]))
-            )
+            update_factor!(factors(A)[k + n][:, r],
+                           factors(A)[k][:, r],
+                           M,
+                           inv(loadings(A)[r] *
+                               dot(factors(A)[k][:, r], G, factors(A)[k][:, r])))
 
             # update outer product of Kruskal factors
-            U[r][k] = factors(A)[k+n][:,r] * factors(A)[k][:,r]'
+            U[r][k] = factors(A)[k + n][:, r] * factors(A)[k][:, r]'
         end
 
         # regressor tensor
@@ -116,24 +113,24 @@ function als!(A::StaticKruskal, ε::TensorNormal, y::AbstractArray)
     # Cholesky decompositions of Σᵢ
     C = cholesky.(Hermitian.(cov(ε)))
     # inverse of Cholesky decompositions
-    Cinv = [inv(C[i].L) for i = 1:n]
+    Cinv = [inv(C[i].L) for i in 1:n]
     # precision matrices Ωᵢ
     Ω = transpose.(Cinv) .* Cinv
 
     # outer product of Kruskal factors
-    U = [[factors(A)[i+n][:,r] * factors(A)[i][:,r]' for i = 1:n] for r = 1:rank(A)]
+    U = [[factors(A)[i + n][:, r] * factors(A)[i][:, r]' for i in 1:n] for r in 1:rank(A)]
 
     # scaling
-    S = [[Cinv[i] * U[r][i] for i = 1:n] for r = 1:rank(A)]
+    S = [[Cinv[i] * U[r][i] for i in 1:n] for r in 1:rank(A)]
 
     # lag and lead variables
-    y_lead = selectdim(y, n+1, 2:last(dims))
-    y_lag = selectdim(y, n+1, 1:last(dims)-1)
+    y_lead = selectdim(y, n + 1, 2:last(dims))
+    y_lag = selectdim(y, n + 1, 1:(last(dims) - 1))
 
     # initialize residuals
     resid(ε) .= y_lead
 
-    for r = 1:rank(A)
+    for r in 1:rank(A)
         s = setdiff(1:rank(A), r)
         # dependent variable tensor
         Zr = copy(y_lead)
@@ -141,7 +138,7 @@ function als!(A::StaticKruskal, ε::TensorNormal, y::AbstractArray)
             Xi = tucker(y_lag, U[i])
             Zr .-= loadings(A)[i] .* Xi
         end
-        for k = 1:n
+        for k in 1:n
             m = setdiff(1:n, k)
             # matricize dependent variable along k-th mode
             Zr_scaled = tucker(Zr, Cinv[m], m)
@@ -156,26 +153,24 @@ function als!(A::StaticKruskal, ε::TensorNormal, y::AbstractArray)
             M = Zkr * Xkr'
 
             # update factor k
-            update_factor!(
-                factors(A)[k][:,r], 
-                factors(A)[k+n][:,r], 
-                G \ M' * Ω[k], 
-                inv(loadings(A)[r] * dot(factors(A)[k+n][:,r], Ω[k], factors(A)[k+n][:,r]))
-            )
+            update_factor!(factors(A)[k][:, r],
+                           factors(A)[k + n][:, r],
+                           G \ M' * Ω[k],
+                           inv(loadings(A)[r] *
+                               dot(factors(A)[k + n][:, r], Ω[k], factors(A)[k + n][:, r])))
             # update factor k+n
-            update_factor!(
-                factors(A)[k+n][:,r], 
-                factors(A)[k][:,r], 
-                M, 
-                inv(loadings(A)[r] * dot(factors(A)[k][:,r], G, factors(A)[k][:,r]))
-            )
-            
+            update_factor!(factors(A)[k + n][:, r],
+                           factors(A)[k][:, r],
+                           M,
+                           inv(loadings(A)[r] *
+                               dot(factors(A)[k][:, r], G, factors(A)[k][:, r])))
+
             # update outer product of Kruskal factors
-            U[r][k] = factors(A)[k+n][:,r] * factors(A)[k][:,r]'
+            U[r][k] = factors(A)[k + n][:, r] * factors(A)[k][:, r]'
 
             # update covariance
             Ek = Zkr - loadings(A)[r] .* U[r][k] * Xkr
-            mul!(cov(ε)[k].data, Ek, Ek', inv((last(dims) - 1) * prod(dims[m])), .0)
+            mul!(cov(ε)[k].data, Ek, Ek', inv((last(dims) - 1) * prod(dims[m])), 0.0)
             # normalize
             k != n && lmul!(inv(norm(cov(ε)[k])), cov(ε)[k].data)
 
@@ -184,7 +179,7 @@ function als!(A::StaticKruskal, ε::TensorNormal, y::AbstractArray)
 
             # update precision matrix
             Ω[k] = transpose(Cinv)[k] .* Cinv[k]
-        
+
             # update scaling
             S[r][k] = Cinv[k] * U[r][k]
         end
@@ -203,66 +198,64 @@ function als!(A::StaticKruskal, ε::TensorNormal, y::AbstractArray)
     return nothing
 end
 
-function als!(
-    A::DynamicKruskal, 
-    ε::TensorNormal, 
-    y::AbstractArray, 
-    V::AbstractVector
-)
+function als!(A::DynamicKruskal,
+              ε::TensorNormal,
+              y::AbstractArray,
+              V::AbstractVector)
     dims = size(y)
     n = ndims(y) - 1
 
     # Cholesky decompositions of Σᵢ
     C = cholesky.(Hermitian.(cov(ε)))
     # inverse of Cholesky decompositions
-    Cinv = [inv(C[i].L) for i = 1:n]
+    Cinv = [inv(C[i].L) for i in 1:n]
     # precision matrices Ωᵢ
     Ω = transpose.(Cinv) .* Cinv
 
     # outer product of Kruskal factors
-    U = [[factors(A)[i+n][:,r] * factors(A)[i][:,r]' for i = 1:n] for r = 1:rank(A)]
+    U = [[factors(A)[i + n][:, r] * factors(A)[i][:, r]' for i in 1:n] for r in 1:rank(A)]
 
     # lag and lead variables
-    y_lead = selectdim(y, n+1, 2:last(dims))
-    y_lag = selectdim(y, n+1, 1:last(dims)-1)
+    y_lead = selectdim(y, n + 1, 2:last(dims))
+    y_lag = selectdim(y, n + 1, 1:(last(dims) - 1))
 
     # Cholesky decomposition of V
     v_half = similar(loadings(A), rank(A) * (rank(A) + 1) ÷ 2, last(dims))
     for (t, Vt) in pairs(V)
         F = cholesky(Hermitian(Vt))
         offset = 0
-        for r = 1:rank(A)
-            for s = r:rank(A)
-                v_half[offset + s - r + 1,t] .= F.L[s,r]
+        for r in 1:rank(A)
+            for s in r:rank(A)
+                v_half[offset + s - r + 1, t] .= F.L[s, r]
             end
             offset += rank(A) - r + 1
         end
     end
 
     # Gram matrix scaling
-    scale = loadings(A).^2
-    for t = 1:last(dims), r = 1:rank(A), s = 1:r
-        scale[r,t] += v_half[r + (s - 1) * rank(A),t]^2
+    scale = loadings(A) .^ 2
+    for t in 1:last(dims), r in 1:rank(A), s in 1:r
+        scale[r, t] += v_half[r + (s - 1) * rank(A), t]^2
     end
 
     # initialize regressor tensors
-    X = [tucker(y_lag, U[r]) for r = 1:rank(A)]
+    X = [tucker(y_lag, U[r]) for r in 1:rank(A)]
 
-    for r = 1:rank(A)
+    for r in 1:rank(A)
         r_ = setdiff(1:rank(A), r)
-        for k = 1:n
+        for k in 1:n
             m = setdiff(1:n, k)
             # matricize dependent variable along k-th mode
             Zr = copy(y_lead)
-            for (t, Zrt) in pairs(eachslice(Zr, dims=n+1))
-                Zrt .*= loadings(A)[r,t]
+            for (t, Zrt) in pairs(eachslice(Zr, dims = n + 1))
+                Zrt .*= loadings(A)[r, t]
                 for s in r_
-                    τ = loadings(A)[r,t] .* loadings(A)[s,t]
-                    for p = 1:min(r, s)
+                    τ = loadings(A)[r, t] .* loadings(A)[s, t]
+                    for p in 1:min(r, s)
                         offset = (p - 1) * rank(A)
-                        τ += v_half[r + offset,t] * v_half[s + offset,t]
+                        τ += v_half[r + offset, t] * v_half[s + offset, t]
                     end
-                    Zrt .-= τ .* selectdim(X[s], n+1, t)
+                    Zrt .-= τ .* selectdim(X[s], n + 1, t)
                 end
             end
             Zr_scaled = tucker(Zr, Cinv[m], m)
@@ -273,30 +266,26 @@ function als!(
 
             # Gram matrix
             G = zeros(dims[k], dims[k])
-            for (t, Xkrt) in pairs(eachslice(Xkr, dims=n+1))
-                G .+= scale[r,t] .* Xkrt * Xkrt'
+            for (t, Xkrt) in pairs(eachslice(Xkr, dims = n + 1))
+                G .+= scale[r, t] .* Xkrt * Xkrt'
             end
             G = Xkr * Xkr'
             # moment matrix
             M = Zkr * Xkr'
 
             # update factor k
-            update_factor!(
-                factors(A)[k][:,r], 
-                factors(A)[k+n][:,r], 
-                G \ M' * Ω[k], 
-                inv(dot(factors(A)[k+n][:,r], Ω[k], factors(A)[k+n][:,r]))
-            )
+            update_factor!(factors(A)[k][:, r],
+                           factors(A)[k + n][:, r],
+                           G \ M' * Ω[k],
+                           inv(dot(factors(A)[k + n][:, r], Ω[k], factors(A)[k + n][:, r])))
             # update factor k+n
-            update_factor!(
-                factors(A)[k+n][:,r], 
-                factors(A)[k][:,r], 
-                M, 
-                inv(dot(factors(A)[k][:,r], G, factors(A)[k][:,r]))
-            )
+            update_factor!(factors(A)[k + n][:, r],
+                           factors(A)[k][:, r],
+                           M,
+                           inv(dot(factors(A)[k][:, r], G, factors(A)[k][:, r])))
 
             # update outer product of Kruskal factors
-            U[r][k] = factors(A)[k+n][:,r] * factors(A)[k][:,r]'
+            U[r][k] = factors(A)[k + n][:, r] * factors(A)[k][:, r]'
             # update regressor tensor
             X[r] = tucker(y_lag, U[r])
         end
@@ -304,13 +293,13 @@ function als!(
 
     # error tensor
     E = copy(y_lead)
-    for (t, Et) in pairs(eachslice(E, dims=n+1))
-        for r = 1:rank(A)
-            Et .-= loadings(A)[r,t] .* selectdim(X[r], n+1, t)
+    for (t, Et) in pairs(eachslice(E, dims = n + 1))
+        for r in 1:rank(A)
+            Et .-= loadings(A)[r, t] .* selectdim(X[r], n + 1, t)
         end
     end
 
-    for k = 1:n
+    for k in 1:n
         m = setdiff(1:n, k)
         # matricize error along k-th mode
         E_scaled = tucker(E, Cinv[m], m)
@@ -319,10 +308,10 @@ function als!(
         # update covariance
         mul!(cov(ε)[k].data, Ek, Ek')
         offset = 0
-        for r = 1:rank(A)
+        for r in 1:rank(A)
             Xs = zero(X[r])
-            for s = r:rank(A)
-                Xs .+= v_half[offset + s - r + 1,t] .* X[s]
+            for s in r:rank(A)
+                Xs .+= v_half[offset + s - r + 1, t] .* X[s]
             end
             Xs_scaled = tucker(Xs, Cinv[m])
             Xks = matricize(Xs_scaled, k)
@@ -330,16 +319,16 @@ function als!(
             offset += rank(A) - r + 1
         end
         lmul!(inv((last(dims) - 1) * prod(dims[m])), cov(ε)[k].data)
-        
+
         # normalize
         k != n && lmul!(inv(norm(cov(ε)[k])), cov(ε)[k].data)
     end
 
     # update residuals
     resid(ε) .= y_lead
-    for (t, εt) in pairs(eachslice(resid(ε), dims=n+1))
-        for r = 1:rank(A)
-            εt .-= loadings(A)[r,t] .* selectdim(X[r], n+1, t)
+    for (t, εt) in pairs(eachslice(resid(ε), dims = n + 1))
+        for r in 1:rank(A)
+            εt .-= loadings(A)[r, t] .* selectdim(X[r], n + 1, t)
         end
     end
 
@@ -352,18 +341,16 @@ end
 Update transition dynamics of dynamic Kruskal coefficient tensor `A` using
 smoothed loadings variance `V`, and autocovariance `Γ`.
 """
-function update_transition!(
-    A::DynamicKruskal, 
-    V::AbstractVector, 
-    Γ::AbstractVector
-)
+function update_transition!(A::DynamicKruskal,
+                            V::AbstractVector,
+                            Γ::AbstractVector)
     T = length(V)
 
     # objective closures
     function f_intercept(x, r)
         f = zero(x)
-        for t = 2:T
-           f -= 2 * (loadings(A)[r,t] - dynamics(A).diag[r] * loadings(A)[r,t-1]) * x
+        for t in 2:T
+            f -= 2 * (loadings(A)[r, t] - dynamics(A).diag[r] * loadings(A)[r, t - 1]) * x
         end
         f = x^2 + f / (T - 1)
 
@@ -373,10 +360,12 @@ function update_transition!(
         scale = one(x) - x^2
         α = intercept(A)[r]
         f = zero(x)
-        for t = 2:T
-            f += V[t][r,r] + loadings(A)[r,t]^2 - 2 * α * loadings(A)[r,t]
-            f += 2 * (α * loadings(A)[r,t-1] - Γ[t-1][r,r] - loadings(A)[r,t] * loadings(A)[r,t-1]) * x
-            f += (V[t-1][r,r] + loadings(A)[r,t-1]^2) * x^2
+        for t in 2:T
+            f += V[t][r, r] + loadings(A)[r, t]^2 - 2 * α * loadings(A)[r, t]
+            f += 2 *
+                 (α * loadings(A)[r, t - 1] - Γ[t - 1][r, r] -
+                  loadings(A)[r, t] * loadings(A)[r, t - 1]) * x
+            f += (V[t - 1][r, r] + loadings(A)[r, t - 1]^2) * x^2
         end
         f = α^2 + f / (T - 1)
 
@@ -384,12 +373,12 @@ function update_transition!(
     end
 
     # update dynamics
-    for r = 1:rank(A)
+    for r in 1:rank(A)
         objective(x) = f_dynamics(x, r)
         res = optimize(f_dynamics, 0.0, 1.0)
         dynamics(A).diag[r] = Optim.minimizer(res)
     end
-    for r = 1:rank(A)
+    for r in 1:rank(A)
         objective(x) = f_intercept(x, r)
         res = optimize(f_intercept, 0.0, 0.7 * (1 - dynamics(A).diag[r]))
         intercept(A)[r] = Optim.minimizer(res)
@@ -405,11 +394,12 @@ end
 Update and normalize factor `u` using regression based on projection matrix `P`
 and companion factor `w`.
 """
-function update_factor!(u::AbstractVecOrMat, w::AbstractVecOrMat, P::AbstractMatrix, scale::Real)
+function update_factor!(u::AbstractVecOrMat, w::AbstractVecOrMat, P::AbstractMatrix,
+                        scale::Real)
     # update factor
     mul!(u, P, w, scale, zero(eltype(u)))
     # normalize
-    u .*= inv(norm(u)) 
+    u .*= inv(norm(u))
 
     return nothing
 end

--- a/src/fit/utilities.jl
+++ b/src/fit/utilities.jl
@@ -17,18 +17,18 @@ Wrapper for objective function evaluation for tensor autoregressive model `model
 objective(model::AbstractTensorAutoregression) = loglikelihood(model)
 function objective(model::StaticTensorAutoregression)
     if dist(model) isa WhiteNoise
-        return sse(model)
+        return rss(model)
     else
         return loglikelihood(model)
     end
 end
 
 """
-    sse(model) -> sse
+    rss(model) -> rss
 
-Evaluate sum of squared errors of the tensor autoregressive model `model`.
+Evaluate residual sum of squares of the tensor autoregressive model `model`.
 """
-function sse(model::AbstractTensorAutoregression)
+function rss(model::AbstractTensorAutoregression)
     update_resid!(model)
     return norm(resid(model))^2
 end

--- a/src/fit/utilities.jl
+++ b/src/fit/utilities.jl
@@ -16,12 +16,12 @@ utilities.jl
 Wrapper for objective function evaluation for tensor autoregressive model
 `model`.
 """
-objective(model::AbstractTensorAutoregression) = loglike(model)
+objective(model::AbstractTensorAutoregression) = loglikelihood(model)
 function objective(model::StaticTensorAutoregression)
     if dist(model) isa WhiteNoise
         return sse(model)
     else
-        return loglike(model)
+        return loglikelihood(model)
     end
 end
 
@@ -36,11 +36,11 @@ function sse(model::AbstractTensorAutoregression)
 end
 
 """
-    loglike(model) -> ll
+    loglikelihood(model) -> ll
 
 Evaluate log-likelihood of the tensor autoregressive model `model`.
 """
-function loglike(model::StaticTensorAutoregression)
+function loglikelihood(model::StaticTensorAutoregression)
     dist(model) isa WhiteNoise && error("Log-likelihood not available for white noise error distribution.")
 
     dims = size(data(model))
@@ -66,7 +66,7 @@ function loglike(model::StaticTensorAutoregression)
     return ll
 end
 
-function loglike(model::DynamicTensorAutoregression)
+function loglikelihood(model::DynamicTensorAutoregression)
     dims = size(data(model))
     n = ndims(data(model)) - 1
 

--- a/src/fit/utilities.jl
+++ b/src/fit/utilities.jl
@@ -23,21 +23,11 @@ function objective(model::StaticTensorAutoregression)
     end
 end
 
-"""
-    rss(model) -> rss
-
-Evaluate residual sum of squares of the tensor autoregressive model `model`.
-"""
 function rss(model::AbstractTensorAutoregression)
     update_resid!(model)
     return norm(resid(model))^2
 end
 
-"""
-    loglikelihood(model) -> ll
-
-Evaluate log-likelihood of the tensor autoregressive model `model`.
-"""
 function loglikelihood(model::StaticTensorAutoregression)
     dist(model) isa WhiteNoise &&
         error("Log-likelihood not available for white noise error distribution.")

--- a/src/fit/utilities.jl
+++ b/src/fit/utilities.jl
@@ -305,7 +305,7 @@ function init!(A::AbstractKruskal, y::AbstractArray, fixed::NamedTuple, method::
             intercept(A)[r] = haskey(fixed, :intercept) ? fixed.intercept[r] : βr[1]
             dynamics(A).diag[r] .= haskey(fixed, :dynamics) ? fixed.dynamics.diag[r] : βr[2]
         end
-        cov(A).data .= I - dynamics(A) * dynamics(A)'
+        cov(A) .= I - dynamics(A) * dynamics(A)'
     end
 
     return nothing

--- a/src/fit/utilities.jl
+++ b/src/fit/utilities.jl
@@ -1,9 +1,8 @@
 #=
 utilities.jl
 
-    Provides a collection of utility tools for fitting tensor autoregressive
-    models, such as initialization, convergence checks, and log-likelihood
-    evaluation.
+    Provides a collection of utility tools for fitting tensor autoregressive models, such as
+    initialization, convergence checks, and log-likelihood evaluation.
 
 @author: Quint Wiersma <q.wiersma@vu.nl>
 
@@ -13,8 +12,7 @@ utilities.jl
 """
     objective(model) -> f
 
-Wrapper for objective function evaluation for tensor autoregressive model
-`model`.
+Wrapper for objective function evaluation for tensor autoregressive model `model`.
 """
 objective(model::AbstractTensorAutoregression) = loglikelihood(model)
 function objective(model::StaticTensorAutoregression)
@@ -66,7 +64,6 @@ function loglikelihood(model::StaticTensorAutoregression)
 
     return ll
 end
-
 function loglikelihood(model::DynamicTensorAutoregression)
     dims = size(data(model))
     n = ndims(data(model)) - 1
@@ -133,7 +130,6 @@ function update_resid!(model::StaticTensorAutoregression)
 
     return nothing
 end
-
 function update_resid!(model::DynamicTensorAutoregression)
     dims = size(y)
     n = ndims(y) - 1
@@ -165,39 +161,30 @@ end
 Initialize the tensor autoregressive model `model` by `method`.
 
 When `method` is set to `:data`:
-- Initialization of the Kruskal coefficient tensor is based on ridge regression of
-the vectorized model combined with a CP decomposition. In case of a dynamic
-Kruskal tensor the dynamic paramaters are obtained from the factor model
-representation of the model.
-- Initiliazation of the tensor error distribution is based on the sample
-covariance estimate of the residuals. In case of separability of the covariance
-matrix a mode specific sample covariance is calculated.
+
+  - Initialization of the Kruskal coefficient tensor is based on ridge regression of the
+    vectorized model combined with a CP decomposition. In case of a dynamic Kruskal tensor
+    the dynamic paramaters are obtained from the factor model representation of the model.
+  - Initiliazation of the tensor error distribution is based on the sample covariance
+    estimate of the residuals. In case of separability of the covariance matrix a mode
+    specific sample covariance is calculated.
 
 When `method` is set to `:random`:
-- Initialization of the Kruskal coefficient tensor is based on a randomly sampled
-CP decomposition. In case of a dynamic Kruskal tensor the dynamic paramaters are
-obtained from the factor model representation of the model.
-- Initiliazation of the tensor error distribution is based on a randomly sampled
-covariance matrix from an inverse Wishart distribution.
 
-When `method` is set to `:none` no initialization is performed and model is
-assumed to have been initialized manually before fitting.
+  - Initialization of the Kruskal coefficient tensor is based on a randomly sampled CP
+    decomposition. In case of a dynamic Kruskal tensor the dynamic paramaters are obtained
+    from the factor model representation of the model.
+  - Initiliazation of the tensor error distribution is based on a randomly sampled
+    covariance matrix from an inverse Wishart distribution.
+
+When `method` is set to `:none` no initialization is performed and model is assumed to have
+been initialized manually before fitting.
 """
 function init!(model::AbstractTensorAutoregression, method::NamedTuple)
     # initialize Kruskal coefficient tensor
-    if method.coef != :none
-        init!(coef(model),
-              data(model),
-              method.coef)
-    end
-
+    method.coef != :none && init!(coef(model), data(model), method.coef)
     # initialize tensor error distribution
-    if method.dist != :none
-        init!(dist(model),
-              data(model),
-              coef(model),
-              method.dist)
-    end
+    method.dist != :none && init!(dist(model), data(model), coef(model), method.dist)
 
     return nothing
 end
@@ -208,15 +195,15 @@ end
 Initialize the Kruskal coefficient tensor `A` given the data `y` using `method`.
 
 When `method` is set to `:data`:
-Initialization of the Kruskal coefficient tensor is based on ridge regression of
-the vectorized model combined with a CP decomposition.
+Initialization of the Kruskal coefficient tensor is based on ridge regression of the
+vectorized model combined with a CP decomposition.
 
 When `method` is set to `:random`:
-Initialization of the Kruskal coefficient tensor is based on a randomly sampled
-CP decomposition.
+Initialization of the Kruskal coefficient tensor is based on a randomly sampled CP
+decomposition.
 
-In case of a dynamic Kruskal tensor the dynamic paramaters are obtained from the
-factor model representation of the model.
+In case of a dynamic Kruskal tensor the dynamic paramaters are obtained from the factor
+model representation of the model.
 """
 function init!(A::AbstractKruskal, y::AbstractArray, method::Symbol)
     dims = size(y)
@@ -300,21 +287,19 @@ end
 """
     init!(ε, y, A, method)
 
-Initialize the tensor error distribution `ε` given the data `y` and the Kruskal
-coefficent tensor `A` using `method`.
+Initialize the tensor error distribution `ε` given the data `y` and the Kruskal coefficent
+tensor `A` using `method`.
 
 When `method` is set to `:data`:
-Initiliazation of the tensor error distribution is based on the sample
-covariance estimate of the residuals. In case of separability of the covariance
-matrix a mode specific sample covariance is calculated.
+Initiliazation of the tensor error distribution is based on the sample covariance estimate
+of the residuals. In case of separability of the covariance matrix a mode specific sample
+covariance is calculated.
 
 When `method` is set to `:random`:
-Initialization of the tensor error distribution is based on a randomly sampled
-covariance matrix from an inverse Wishart distribution.
+Initialization of the tensor error distribution is based on a randomly sampled covariance
+matrix from an inverse Wishart distribution.
 """
-function init!(ε::AbstractTensorErrorDistribution,
-               y::AbstractArray,
-               A::AbstractKruskal,
+function init!(ε::AbstractTensorErrorDistribution, y::AbstractArray, A::AbstractKruskal,
                method::Symbol)
     dims = size(y)
     n = ndims(y) - 1

--- a/src/fit/utilities.jl
+++ b/src/fit/utilities.jl
@@ -347,32 +347,3 @@ function init!(ε::AbstractTensorErrorDistribution, y::AbstractArray, A::Abstrac
 
     return nothing
 end
-
-"""
-    absdiff(x, y) -> δ
-
-Calculate the maximum absolute difference between `x` and `y`.
-"""
-absdiff(x::AbstractArray, y::AbstractArray) = mapreduce((xi, yi) -> abs(xi - yi), max, x, y)
-absdiff(ε::WhiteNoise, ε_prev::WhiteNoise) = absdiff(cov(ε), cov(ε_prev))
-absdiff(ε::TensorNormal, ε_prev::TensorNormal) = maximum(absdiff.(cov(ε), cov(ε_prev)))
-function absdiff(A::StaticKruskal, A_prev::StaticKruskal)
-    δ_loadings = absdiff(loadings(A), loadings(A_prev))
-    δ_factors = maximum(absdiff.(factors(A), factors(A_prev)))
-
-    return max(δ_loadings, δ_factors)
-end
-function absdiff(A::DynamicKruskal, A_prev::DynamicKruskal)
-    δ_factors = maximum(absdiff.(factors(A), factors(A_prev)))
-    δ_dynamics = absdiff(dynamics(A), dynamics(A_prev))
-    δ_cov = absdiff(cov(A), cov(A_prev))
-
-    return max(δ_factors, δ_dynamics, δ_cov)
-end
-function absdiff(model::AbstractTensorAutoregression,
-                 model_prev::AbstractTensorAutoregression)
-    δ_coef = absdiff(coef(model), coef(model_prev))
-    δ_dist = absdiff(dist(model), dist(model_prev))
-
-    return max(δ_coef, δ_dist)
-end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -112,7 +112,7 @@ function simulate(model::StaticTensorAutoregression; burn::Integer = 100,
         end
     end
 
-    return StaticTensorAutoregression(y_sim, ε_sim, A_sim, fixed(model))
+    return StaticTensorAutoregression(y_sim, ε_sim, A_sim)
 end
 function simulate(model::DynamicTensorAutoregression; burn::Integer = 100,
                   rng::AbstractRNG = Xoshiro())
@@ -158,7 +158,7 @@ function simulate(model::DynamicTensorAutoregression; burn::Integer = 100,
         end
     end
 
-    return DynamicTensorAutoregression(y_sim, ε_sim, A_sim, fixed(model))
+    return DynamicTensorAutoregression(y_sim, ε_sim, A_sim)
 end
 
 """

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,8 +1,8 @@
 #=
 interface.jl
 
-    Provides a collection of interface tools for working with tensor autoregressive
-    models, such as estimation, forecasting, and impulse response analysis.
+    Provides a collection of interface tools for working with tensor autoregressive models,
+    such as estimation, forecasting, and impulse response analysis.
 
 @author: Quint Wiersma <q.wiersma@vu.nl>
 
@@ -10,20 +10,12 @@ interface.jl
 =#
 
 """
-    TensorAutoregression(
-        y,
-        R;
-        dynamic=false,
-        dist=:white_noise
-    ) -> model
+    TensorAutoregression(y, R; dynamic=false, dist=:white_noise) -> model
 
-Constructs a tensor autoregressive model for data `y` with autoregressive
-coefficient tensor of rank `R`, potentially dynamic, and tensor error
-distribution `dist`.
+Constructs a tensor autoregressive model for data `y` with autoregressive coefficient tensor
+of rank `R`, potentially dynamic, and tensor error distribution `dist`.
 """
-function TensorAutoregression(y::AbstractArray,
-                              R::Integer;
-                              dynamic::Bool = false,
+function TensorAutoregression(y::AbstractArray, R::Integer; dynamic::Bool = false,
                               dist::Symbol = :white_noise)
     dims = size(y)
     n = ndims(y) - 1
@@ -34,17 +26,13 @@ function TensorAutoregression(y::AbstractArray,
 
     # instantiate Kruskal autoregressive tensor
     if dynamic
-        A = DynamicKruskal(similar(y, R, last(dims) - 1),
-                           similar(y, R),
-                           Diagonal(similar(y, R)),
-                           Diagonal(similar(y, R)),
-                           [similar(y, dims[i - n * ((i - 1) ÷ n)], R) for i in 1:(2n)],
-                           R)
+        A = DynamicKruskal(similar(y, R, last(dims) - 1), similar(y, R),
+                           Diagonal(similar(y, R)), Diagonal(similar(y, R)),
+                           [similar(y, dims[i - n * ((i - 1) ÷ n)], R) for i in 1:(2n)], R)
         model = DynamicTensorAutoregression
     else
         A = StaticKruskal(similar(y, R),
-                          [similar(y, dims[i - n * ((i - 1) ÷ n)], R) for i in 1:(2n)],
-                          R)
+                          [similar(y, dims[i - n * ((i - 1) ÷ n)], R) for i in 1:(2n)], R)
         model = StaticTensorAutoregression
     end
 
@@ -64,22 +52,14 @@ function TensorAutoregression(y::AbstractArray,
 end
 
 """
-    TensorAutoregression(
-        dims,
-        R;
-        dynamic=false,
-        dist=:white_noise
-    ) -> model
+    TensorAutoregression(dims, R; dynamic=false, dist=:white_noise) -> model
 
-Constructs a tensor autoregressive model of dimensions `dims` with
-autoregressive coefficient tensor of rank `R`, potentially dynamic, and tensor
-error distribution `dist`.
+Constructs a tensor autoregressive model of dimensions `dims` with autoregressive
+coefficient tensor of rank `R`, potentially dynamic, and tensor error distribution `dist`.
 """
-function TensorAutoregression(dims::Dims,
-                              R::Integer;
-                              dynamic::Bool = false,
+function TensorAutoregression(dims::Dims, R::Integer; dynamic::Bool = false,
                               dist::Symbol = :white_noise)
-    return TensorAutoregression(zeros(dims), R, dynamic = dynamic, dist = dist)
+    TensorAutoregression(zeros(dims), R, dynamic = dynamic, dist = dist)
 end
 
 """
@@ -89,8 +69,8 @@ Simulate data from the tensor autoregressive model described by `model` and
 return a new instance with the simulated data, using random number generator
 `rng` and apply a burn-in period of `burn`.
 """
-function simulate(model::StaticTensorAutoregression;
-                  burn::Integer = 100, rng::AbstractRNG = Xoshiro())
+function simulate(model::StaticTensorAutoregression; burn::Integer = 100,
+                  rng::AbstractRNG = Xoshiro())
     dims = size(data(model))
     n = ndims(data(model)) - 1
 
@@ -134,9 +114,8 @@ function simulate(model::StaticTensorAutoregression;
 
     return StaticTensorAutoregression(y_sim, ε_sim, A_sim, fixed(model))
 end
-
-function simulate(model::DynamicTensorAutoregression;
-                  burn::Integer = 100, rng::AbstractRNG = Xoshiro())
+function simulate(model::DynamicTensorAutoregression; burn::Integer = 100,
+                  rng::AbstractRNG = Xoshiro())
     dims = size(data(model))
     n = ndims(data(model)) - 1
 
@@ -183,30 +162,20 @@ function simulate(model::DynamicTensorAutoregression;
 end
 
 """
-    fit!(
-        model;
-        init_method=(coef=:data, dist=:data),
-        ϵ=1e-4,
-        max_iter=1000,
-        verbose=false
-    ) -> model
+    fit!(model; init_method=(coef=:data, dist=:data), ϵ=1e-4, max_iter=1000, verbose=false) -> model
 
-Fit the tensor autoregressive model described by `model` to the data with
-tolerance `ϵ` and maximum number of iterations `max_iter`. If `verbose` is true
-a summary of the model fitting is printed. `init_method` indicates which method
-is used for initialization of the parameters.
+Fit the tensor autoregressive model described by `model` to the data with tolerance `ϵ` and
+maximum number of iterations `max_iter`. If `verbose` is true a summary of the model fitting
+is printed. `init_method` indicates which method is used for initialization of the parameters.
 
-Estimation is done using the Expectation-Maximization algorithm for
-obtaining the maximum likelihood estimates of the dynamic model and the
-alternating least squares (ALS) algorithm for obtaining the least squares and
-maximum likelihood estimates of the static model, for respectively white noise
-and tensor normal errors.
+Estimation is done using the Expectation-Maximization algorithm for obtaining the maximum
+likelihood estimates of the dynamic model and the alternating least squares (ALS) algorithm
+for obtaining the least squares and maximum likelihood estimates of the static model, for
+respectively white noise and tensor normal errors.
 """
 function fit!(model::AbstractTensorAutoregression;
               init_method::NamedTuple = (coef = :data, dist = :data),
-              ϵ::AbstractFloat = 1e-4,
-              max_iter::Integer = 1000,
-              verbose::Bool = false)
+              ϵ::AbstractFloat = 1e-4, max_iter::Integer = 1000, verbose::Bool = false)
     keys(init_method) ⊇ (:coef, :dist) ||
         error("init_method must be a NamedTuple with keys :coef and :dist.")
 
@@ -285,7 +254,6 @@ function forecast(model::StaticTensorAutoregression, periods::Integer)
 
     return forecasts
 end
-
 function forecast(model::DynamicTensorAutoregression, periods::Integer)
     dims = size(data(model))
     n = ndims(data(model)) - 1
@@ -312,16 +280,12 @@ end
 """
     irf(model, periods; α=.05, orth=false) -> irfs
 
-Compute impulse response functions `periods` periods ahead and corresponding
-`α`% upper and lower confidence bounds using fitted tensor autoregressive model
-`model`. Upper and lower confidence bounds are computed using Monte Carlo
-simulation.
-If `orth` is true, the orthogonalized impulse response functions are
-computed.
+Compute impulse response functions `periods` periods ahead and corresponding `α`% upper and
+lower confidence bounds using fitted tensor autoregressive model `model`. Upper and lower
+confidence bounds are computed using Monte Carlo simulation. If `orth` is true, the
+orthogonalized impulse response functions are computed.
 """
-function irf(model::AbstractTensorAutoregression,
-             periods::Integer;
-             α::Real = 0.05,
+function irf(model::AbstractTensorAutoregression, periods::Integer; α::Real = 0.05,
              orth::Bool = false)
     if model isa StaticTensorAutoregression
         irf_type = StaticIRF

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,8 +1,8 @@
 #=
 interface.jl
 
-    Provides a collection of interface tools for working with tensor autoregressive 
-    models, such as estimation, forecasting, and impulse response analysis. 
+    Provides a collection of interface tools for working with tensor autoregressive
+    models, such as estimation, forecasting, and impulse response analysis.
 
 @author: Quint Wiersma <q.wiersma@vu.nl>
 
@@ -11,9 +11,9 @@ interface.jl
 
 """
     TensorAutoregression(
-        y, 
-        R; 
-        dynamic=false, 
+        y,
+        R;
+        dynamic=false,
         dist=:white_noise
     ) -> model
 
@@ -65,9 +65,9 @@ end
 
 """
     TensorAutoregression(
-        dims, 
-        R; 
-        dynamic=false, 
+        dims,
+        R;
+        dynamic=false,
         dist=:white_noise
     ) -> model
 
@@ -102,8 +102,7 @@ function simulate(model::StaticTensorAutoregression;
     (ε_sim, ε_burn) = simulate(dist(model), burn + 1, rng)
 
     # outer product of Kruskal factors
-    U = [[factors(A_sim)[i + n][:, r] * factors(A_sim)[i][:, r]' for i in 1:n]
-         for r in 1:rank(A_sim)]
+    U = outer(coef(model))
 
     # burn-in
     y_burn = similar(data(model), dims[1:n]..., burn + 1)
@@ -148,8 +147,7 @@ function simulate(model::DynamicTensorAutoregression;
     (ε_sim, ε_burn) = simulate(dist(model), burn + 1, rng)
 
     # outer product of Kruskal factors
-    U = [[factors(A_sim)[i + n][:, r] * factors(A_sim)[i][:, r]' for i in 1:n]
-         for r in 1:rank(A_sim)]
+    U = outer(coef(model))
 
     # burn-in
     y_burn = similar(data(model), dims[1:n]..., burn + 1)
@@ -186,10 +184,10 @@ end
 
 """
     fit!(
-        model;  
-        init_method=(coef=:data, dist=:data), 
-        ϵ=1e-4, 
-        max_iter=1000, 
+        model;
+        init_method=(coef=:data, dist=:data),
+        ϵ=1e-4,
+        max_iter=1000,
         verbose=false
     ) -> model
 
@@ -274,8 +272,7 @@ function forecast(model::StaticTensorAutoregression, periods::Integer)
     n = ndims(data(model)) - 1
 
     # outer product of Kruskal factors
-    U = [[factors(model)[i + n][:, r] * factors(model)[i][:, r]' for i in 1:n]
-         for r in 1:rank(model)]
+    U = outer(coef(model))
 
     # forecast data using tensor autoregression
     forecasts = similar(data(model), dims[1:n]..., periods)
@@ -297,8 +294,7 @@ function forecast(model::DynamicTensorAutoregression, periods::Integer)
     particles = particle_sampler(model, periods)
 
     # outer product of Kruskal factors
-    U = [[factors(model)[i + n][:, r] * factors(model)[i][:, r]' for i in 1:n]
-         for r in 1:rank(model)]
+    U = outer(coef(model))
 
     # forecast data using tensor autoregression
     forecasts = similar(data(model), dims[1:n]..., periods)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -14,20 +14,18 @@ interface.jl
         y, 
         R; 
         dynamic=false, 
-        dist=:white_noise,
-        fixed=NamedTuple()
+        dist=:white_noise
     ) -> model
 
 Constructs a tensor autoregressive model for data `y` with autoregressive
 coefficient tensor of rank `R`, potentially dynamic, and tensor error
-distribution `dist` and fixed parameters indicated by `fixed`.
+distribution `dist`.
 """
 function TensorAutoregression(
     y::AbstractArray, 
     R::Integer; 
     dynamic::Bool=false, 
-    dist::Symbol=:white_noise,
-    fixed::NamedTuple=NamedTuple()
+    dist::Symbol=:white_noise
 )   
     dims = size(y)
     n = ndims(y) - 1
@@ -41,7 +39,7 @@ function TensorAutoregression(
             similar(y, R, last(dims)-1), 
             similar(y, R), 
             Diagonal(similar(y, R)), 
-            Symmetric(similar(y, R, R)),
+            Diagonal(similar(y, R)),
             [similar(y, dims[i - n*((i-1)÷n)], R) for i = 1:2n], 
             R
         )
@@ -71,7 +69,7 @@ function TensorAutoregression(
         throw(ArgumentError("distribution $dist not supported."))
     end
 
-    return model(y, ε, A, fixed)
+    return model(y, ε, A)
 end
 
 """
@@ -79,22 +77,20 @@ end
         dims, 
         R; 
         dynamic=false, 
-        dist=:white_noise,
-        fixed=NamedTuple()
+        dist=:white_noise
     ) -> model
 
 Constructs a tensor autoregressive model of dimensions `dims` with
 autoregressive coefficient tensor of rank `R`, potentially dynamic, and tensor
-error distribution `dist` and fixed parameters indicated by `fixed`.
+error distribution `dist`.
 """
 function TensorAutoregression(
     dims::Dims, 
     R::Integer; 
     dynamic::Bool=false, 
-    dist::Symbol=:white_noise,
-    fixed::NamedTuple=NamedTuple()
+    dist::Symbol=:white_noise
 )   
-    return TensorAutoregression(zeros(dims), R, dynamic=dynamic, dist=dist, fixed=fixed)
+    return TensorAutoregression(zeros(dims), R, dynamic=dynamic, dist=dist)
 end
 
 """
@@ -231,9 +227,6 @@ function fit!(
         println("Rank: $(rank(model))")
         println("Distribution: $(Base.typename(typeof(dist(model))).wrapper)")
         println("Coefficient tensor: ", coef(model) isa StaticKruskal ? "static" : "dynamic")
-        println("Fixed parameters:")
-        println("   Kruskal tensor: ", haskey(fixed(model), :coef) ? keys(fixed(model).coef) : "none")
-        println("   Distribution: ", haskey(fixed(model), :dist) ? keys(fixed(model).dist) : "none")
         println("===========================")
         println()
     end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -177,7 +177,8 @@ respectively white noise and tensor normal errors.
 """
 function fit!(model::AbstractTensorAutoregression;
               init_method::NamedTuple = (coef = :data, dist = :data),
-              ϵ::AbstractFloat = 1e-4, max_iter::Integer = 1000, verbose::Bool = false)
+              tolerance::AbstractFloat = 1e-4, max_iter::Integer = 1000,
+              verbose::Bool = false)
     keys(init_method) ⊇ (:coef, :dist) ||
         error("init_method must be a NamedTuple with keys :coef and :dist.")
 
@@ -223,7 +224,7 @@ function fit!(model::AbstractTensorAutoregression;
 
         # convergence
         δ = 2 * abs(obj - obj_prev) / (abs(obj) + abs(obj_prev))
-        converged = δ < ϵ
+        converged = δ < tolerance
 
         # update iteration counter
         iter += 1
@@ -294,14 +295,14 @@ function forecast(model::DynamicTensorAutoregression, periods::Integer)
 end
 
 """
-    irf(model, periods; α=.05, orth=false) -> irfs
+    irf(model, periods; alpha=.05, orth=false) -> irfs
 
-Compute impulse response functions `periods` periods ahead and corresponding `α`% upper and
-lower confidence bounds using fitted tensor autoregressive model `model`. Upper and lower
-confidence bounds are computed using Monte Carlo simulation. If `orth` is true, the
+Compute impulse response functions `periods` periods ahead and corresponding `alpha`% upper
+and lower confidence bounds using fitted tensor autoregressive model `model`. Upper and
+lower confidence bounds are computed using Monte Carlo simulation. If `orth` is true, the
 orthogonalized impulse response functions are computed.
 """
-function irf(model::AbstractTensorAutoregression, periods::Integer; α::Real = 0.05,
+function irf(model::AbstractTensorAutoregression, periods::Integer; alpha::Real = 0.05,
              orth::Bool = false)
     if model isa StaticTensorAutoregression
         irf_type = StaticIRF
@@ -316,7 +317,7 @@ function irf(model::AbstractTensorAutoregression, periods::Integer; α::Real = 0
     orth ? Ψ = orthogonalize(Ψ, cov(model)) : nothing
 
     # confidence bounds
-    (lower, upper) = confidence_bounds(model, periods, α, orth)
+    (lower, upper) = confidence_bounds(model, periods, alpha, orth)
 
     return irf_type(Ψ, lower, upper, orth)
 end

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -21,8 +21,8 @@ function data_plot(model::AbstractTensorAutoregression)
     n = ndims(data(model)) - 1
 
     # sort modes
-    maxmode = argmax(dims[1:n-1])
-    m = setdiff(1:n-1, maxmode)
+    maxmode = argmax(dims[1:(n - 1)])
+    m = setdiff(1:(n - 1), maxmode)
 
     # setup subplots
     cols = iseven(dims[maxmode]) ? 2 : 3
@@ -30,39 +30,37 @@ function data_plot(model::AbstractTensorAutoregression)
     indices = CartesianIndices((rows, cols))
 
     # setup figure
-    fig = Figure(resolution=(cols * 800, cols * 600))
-    grids = [GridLayout(fig[Tuple(idx)...]) for idx ∈ indices[1:dims[maxmode]]]
-    axs = [Axis(grid[i, 1]) for grid ∈ grids, i = 1:dims[n]]
-    
+    fig = Figure(resolution = (cols * 800, cols * 600))
+    grids = [GridLayout(fig[Tuple(idx)...]) for idx in indices[1:dims[maxmode]]]
+    axs = [Axis(grid[i, 1]) for grid in grids, i in 1:dims[n]]
+
     # layout
-    for grid ∈ grids
+    for grid in grids
         colgap!(grid, 0)
         rowgap!(grid, 0)
     end
 
     # link axes
     linkxaxes!(axs...)
-    for i = 1:dims[n]
-        linkyaxes!(axs[:,i]...)
+    for i in 1:dims[n]
+        linkyaxes!(axs[:, i]...)
     end
 
     # decorations
-    for i = 1:dims[maxmode]
-        axs[i,end].xlabel = "time"
-        axs[i,end].xticks = (ticks, values)
+    for i in 1:dims[maxmode]
+        axs[i, end].xlabel = "time"
+        axs[i, end].xticks = (ticks, values)
     end
-    hidexdecorations!.(axs[:,1:end-1], grid=false)
-    hideydecorations!.(axs[rows+1:end,:], grid=false)
+    hidexdecorations!.(axs[:, 1:(end - 1)], grid = false)
+    hideydecorations!.(axs[(rows + 1):end, :], grid = false)
 
     # data
     colors = resample_cmap(:viridis, prod(dims[m]))
-    for (idx, ax) ∈ pairs(IndexCartesian(), axs)
+    for (idx, ax) in pairs(IndexCartesian(), axs)
         y = selectdim(data(model), maxmode, idx[1])
-        series!(
-            ax,
-            reshape(selectdim(y, n-1, idx[2]), :, last(dims)), 
-            color=colors
-        )
+        series!(ax,
+                reshape(selectdim(y, n - 1, idx[2]), :, last(dims)),
+                color = colors)
     end
 
     return fig
@@ -73,18 +71,18 @@ function data_plot(model::AbstractTensorAutoregression, labels, time)
     n = ndims(data(model)) - 1
 
     # sort modes
-    maxmode = argmax(dims[1:n-1])
-    m = setdiff(1:n-1, maxmode)
+    maxmode = argmax(dims[1:(n - 1)])
+    m = setdiff(1:(n - 1), maxmode)
 
     # combine time series labels
     sub_labels = labels[m[1]]
-    for mode ∈ m[2:end]
+    for mode in m[2:end]
         sub_labels = vec(sub_labels .* " - " .* reshape(labels[mode], 1, :))
     end
 
     # time ticks
     values = string.(unique(year.(time))[1:5:end])
-    ticks = [findfirst(string.(year.(time)) .== value) for value ∈ values]
+    ticks = [findfirst(string.(year.(time)) .== value) for value in values]
 
     # setup subplots
     cols = iseven(dims[maxmode]) ? 2 : 3
@@ -92,71 +90,65 @@ function data_plot(model::AbstractTensorAutoregression, labels, time)
     indices = CartesianIndices((rows, cols))
 
     # setup figure
-    fig = Figure(resolution=(cols * 800, cols * 600))
-    grids = [GridLayout(fig[Tuple(idx)...]) for idx ∈ indices[1:dims[maxmode]]]
-    axs = [Axis(grid[i, 1]) for grid ∈ grids, i = 1:dims[n]]
-    
+    fig = Figure(resolution = (cols * 800, cols * 600))
+    grids = [GridLayout(fig[Tuple(idx)...]) for idx in indices[1:dims[maxmode]]]
+    axs = [Axis(grid[i, 1]) for grid in grids, i in 1:dims[n]]
+
     # layout
-    for grid ∈ grids
+    for grid in grids
         colgap!(grid, 0)
         rowgap!(grid, 0)
     end
 
     # link axes
     linkxaxes!(axs...)
-    for i = 1:dims[n]
-        linkyaxes!(axs[:,i]...)
+    for i in 1:dims[n]
+        linkyaxes!(axs[:, i]...)
     end
 
     # decorations
-    for i = 1:dims[maxmode], j = 1:dims[n]
-        axs[i,j].xlabel = "time"
-        axs[i,j].xticks = (ticks, values)
+    for i in 1:dims[maxmode], j in 1:dims[n]
+        axs[i, j].xlabel = "time"
+        axs[i, j].xticks = (ticks, values)
     end
-    hidexdecorations!.(axs[:,1:end-1], grid=false)
-    hideydecorations!.(axs[rows+1:end,:], grid=false)
+    hidexdecorations!.(axs[:, 1:(end - 1)], grid = false)
+    hideydecorations!.(axs[(rows + 1):end, :], grid = false)
 
     # grid titles
-    for (i, grid) ∈ pairs(grids)
-        Label(
-            grid[1, :, Top()], 
-            labels[maxmode][i], 
-            valign=:bottom,
-            font=:bold
-        )
+    for (i, grid) in pairs(grids)
+        Label(grid[1, :, Top()],
+              labels[maxmode][i],
+              valign = :bottom,
+              font = :bold)
     end
     # axis titles
-    for grid ∈ grids[end-rows+1:end]
-        for (i, label) ∈ pairs(labels[end])
-            Box(grid[i, 2], color=:gray90)
-            Label(grid[i, 2], label, rotation=π/2, tellheight=false)
+    for grid in grids[(end - rows + 1):end]
+        for (i, label) in pairs(labels[end])
+            Box(grid[i, 2], color = :gray90)
+            Label(grid[i, 2], label, rotation = π / 2, tellheight = false)
         end
         colgap!(grid, 0)
     end
 
     # data
     colors = resample_cmap(:viridis, prod(dims[m]))
-    for (idx, ax) ∈ pairs(IndexCartesian(), axs)
+    for (idx, ax) in pairs(IndexCartesian(), axs)
         y = selectdim(data(model), maxmode, idx[1])
-        series!(
-            ax,
-            reshape(selectdim(y, n-1, idx[2]), :, last(dims)), 
-            color=colors,
-            labels=sub_labels
-        )
+        series!(ax,
+                reshape(selectdim(y, n - 1, idx[2]), :, last(dims)),
+                color = colors,
+                labels = sub_labels)
     end
 
     # add legend
     if dims[maxmode] == length(indices)
-        Legend(fig[:, cols+1], axs[1], "sectors")
+        Legend(fig[:, cols + 1], axs[1], "sectors")
     else
-        Legend(
-            fig[rows, cols], 
-            axs[1], 
-            "sectors", 
-            tellwidth=false, 
-            halign=:left,       
-        )
+        Legend(fig[rows, cols],
+               axs[1],
+               "sectors",
+               tellwidth = false,
+               halign = :left)
     end
 
     return fig
@@ -173,11 +165,11 @@ function kruskal_plot(A::StaticKruskal)
     n = length(dims) ÷ 2
 
     # setup figure
-    fig = Figure(resolution=(1600, 1600))
+    fig = Figure(resolution = (1600, 1600))
     ax = Axis(fig[1, 1])
 
     # Kruskal coefficient tensor factors and static loadings
-    hm = heatmap!(ax, matricize(full(A), n+1:2n)')
+    hm = heatmap!(ax, matricize(full(A), (n + 1):(2n))')
     Colorbar(fig[1, 2], hm)
 
     return fig
@@ -188,7 +180,7 @@ function kruskal_plot(A::StaticKruskal, labels)
     n = length(dims) ÷ 2
 
     # setup figures
-    fig = Figure(resolution=(1600, 1600))
+    fig = Figure(resolution = (1600, 1600))
     # main grids
     gl = GridLayout(fig[1, 1])  # left label grid
     gb = GridLayout(fig[2, 2])  # bottom label grid
@@ -198,13 +190,13 @@ function kruskal_plot(A::StaticKruskal, labels)
     ax = Axis(gm[1, 1])
 
     # label grids
-    for i = 1:dims[n]
+    for i in 1:dims[n]
         nested_labels!(GridLayout(gl[i, 1]), dims, n, i, labels, :left)
         nested_labels!(GridLayout(gb[1, i]), dims, n, i, labels, :bottom)
     end
 
     # Kruskal coefficient tensor
-    hm = heatmap!(ax, matricize(full(A), n+1:2*n)')
+    hm = heatmap!(ax, matricize(full(A), (n + 1):(2 * n))')
     Colorbar(gc[1, 1], hm)
 
     # ticks
@@ -219,15 +211,15 @@ function kruskal_plot(A::DynamicKruskal)
     n = length(dims) ÷ 2
 
     # setup figures
-    figs = [Figure(resolution=(1600, 1600)), Figure()]
-    axs = [Axis(fig[1, 1]) for fig ∈ figs]
+    figs = [Figure(resolution = (1600, 1600)), Figure()]
+    axs = [Axis(fig[1, 1]) for fig in figs]
 
     # Kruskal coefficient tensor factors
-    hm = heatmap!(axs[1], matricize(full(A), n+1:2n)')
+    hm = heatmap!(axs[1], matricize(full(A), (n + 1):(2n))')
     Colorbar(figs[1][1, 2], hm)
 
     # dynamic Kruskal loadings
-    series!(axs[2], loadings(A), color=:viridis)
+    series!(axs[2], loadings(A), color = :viridis)
 
     return figs
 end
@@ -237,7 +229,7 @@ function kruskal_plot(A::DynamicKruskal, labels, time)
     n = length(dims) ÷ 2
 
     # setup figures
-    figs = [Figure(resolution=(1600, 1600)), Figure()]
+    figs = [Figure(resolution = (1600, 1600)), Figure()]
     # main grids
     gl = GridLayout(figs[1][1, 1])  # left label grid
     gb = GridLayout(figs[1][2, 2])  # bottom label grid
@@ -247,13 +239,13 @@ function kruskal_plot(A::DynamicKruskal, labels, time)
     axs = [Axis(gm[1, 1]), Axis(figs[2][1, 1])]
 
     # label grids
-    for i = 1:dims[n]
+    for i in 1:dims[n]
         nested_labels!(GridLayout(gl[i, 1]), dims, n, i, labels, :left)
         nested_labels!(GridLayout(gb[1, i]), dims, n, i, labels, :bottom)
     end
 
     # Kruskal coefficient tensor factors
-    hm = heatmap!(axs[1], matricize(full(A), n+1:2n)')
+    hm = heatmap!(axs[1], matricize(full(A), (n + 1):(2n))')
     Colorbar(gc[1, 1], hm)
 
     # ticks
@@ -261,11 +253,11 @@ function kruskal_plot(A::DynamicKruskal, labels, time)
     axs[1].yticks = (1:prod(dims[1:n]), repeat(labels[1], prod(dims[2:n])))
 
     # dynamic Kruskal loadings
-    series!(axs[2], loadings(A), color=:viridis)
+    series!(axs[2], loadings(A), color = :viridis)
 
     # time ticks
     values = string.(unique(year.(time))[1:5:end])
-    ticks = [findfirst(string.(year.(time)) .== value) for value ∈ values]
+    ticks = [findfirst(string.(year.(time)) .== value) for value in values]
     axs[2].xlabel = "time"
     axs[2].xticks = (ticks, values)
 
@@ -280,11 +272,11 @@ Plot the tensor error covariance structure `ε` with optionally specified
 """
 function cov_plot(ε::AbstractTensorErrorDistribution)
     # setup figure
-    fig = Figure(resolution=(1600, 1600))
+    fig = Figure(resolution = (1600, 1600))
     ax = Axis(fig[1, 1])
 
     # covariance matrix
-    hm = heatmap!(ax, cov(ε, full=true)')
+    hm = heatmap!(ax, cov(ε, full = true)')
     Colorbar(fig[1, 2], hm)
 
     return fig
@@ -295,7 +287,7 @@ function cov_plot(ε::AbstractTensorErrorDistribution, labels)
     n = length(dims)
 
     # setup figures
-    fig = Figure(resolution=(1600, 1600))
+    fig = Figure(resolution = (1600, 1600))
     # main grids
     gl = GridLayout(fig[1, 1])  # left label grid
     gb = GridLayout(fig[2, 2])  # bottom label grid
@@ -305,13 +297,13 @@ function cov_plot(ε::AbstractTensorErrorDistribution, labels)
     ax = Axis(gm[1, 1])
 
     # label grids
-    for i = 1:dims[n]
+    for i in 1:dims[n]
         nested_labels!(GridLayout(gl[i, 1]), dims, n, i, labels, :left)
         nested_labels!(GridLayout(gb[1, i]), dims, n, i, labels, :bottom)
     end
 
     # covariance matrix
-    hm = heatmap!(ax, cov(ε, full=true)')
+    hm = heatmap!(ax, cov(ε, full = true)')
     Colorbar(gc[1, 1], hm)
 
     # ticks
@@ -330,15 +322,16 @@ location of the labels.
 """
 function nested_labels!(grid, dims, n, i, labels, loc)
     # terminate at final to last level (last level are axis ticks)
-    if n == 2  
-        for j = 1:dims[n]
+    if n == 2
+        for j in 1:dims[n]
             # add all remaining labels
             if loc == :bottom
                 Box(grid[1, j])
-                Label(grid[1, j], labels[n][j], tellwidth=false)
+                Label(grid[1, j], labels[n][j], tellwidth = false)
             elseif loc == :left
                 Box(grid[j, 1])
-                Label(grid[j, 1], reverse(labels[n])[j], rotation=π/2, tellheight=false)
+                Label(grid[j, 1], reverse(labels[n])[j], rotation = π / 2,
+                      tellheight = false)
             end
         end
     else
@@ -347,14 +340,14 @@ function nested_labels!(grid, dims, n, i, labels, loc)
         Box(ga[1, 1])
         # add label of current level
         if loc == :bottom
-            Label(ga[1, 1], labels[n][i], tellwidth=false)
+            Label(ga[1, 1], labels[n][i], tellwidth = false)
         elseif loc == :left
-            Label(ga[1, 1], reverse(labels[n])[i], rotation=π/2, tellheight=false)
+            Label(ga[1, 1], reverse(labels[n])[i], rotation = π / 2, tellheight = false)
         end
         # second subgrid (will be recursively filled with new level)
         gb = loc == :left ? GridLayout(grid[1, 2]) : GridLayout(grid[1, 1])
-        for j ∈ 1:dims[n-1]
-            nested_labels!(gb, dims, n-1, j, labels, loc)
+        for j in 1:dims[n - 1]
+            nested_labels!(gb, dims, n - 1, j, labels, loc)
         end
     end
 end
@@ -372,21 +365,22 @@ function irf_plot(irfs::StaticIRF, impulse, response)
 
     # setup figure
     fig = Figure()
-    ax = Axis(
-        fig[1,1], 
-        title=orth(irfs) ? "Orthogonal Impulse Response Function" : "Impulse Response Function",
-        titlealign=:left,
-        titlecolor=:gray50,
-        xlabel="periods",
-        xticks=(0:periods, ["$h" for h = 0:periods])
-    )
+    ax = Axis(fig[1, 1],
+              title = orth(irfs) ? "Orthogonal Impulse Response Function" :
+                      "Impulse Response Function",
+              titlealign = :left,
+              titlecolor = :gray50,
+              xlabel = "periods",
+              xticks = (0:periods, ["$h" for h in 0:periods]))
 
     # impulse response function
-    lines!(ax, 0:periods, ψ, color=:black)
+    lines!(ax, 0:periods, ψ, color = :black)
 
     # confidence bands
-    lines!(ax, 0:periods, lower(irfs, impulse, response), color=:gray50, linestyle=:dash)
-    lines!(ax, 0:periods, upper(irfs, impulse, response), color=:gray50, linestyle=:dash)
+    lines!(ax, 0:periods, lower(irfs, impulse, response), color = :gray50,
+           linestyle = :dash)
+    lines!(ax, 0:periods, upper(irfs, impulse, response), color = :gray50,
+           linestyle = :dash)
 
     return fig
 end
@@ -398,16 +392,15 @@ function irf_plot(irfs::DynamicIRF, impulse, response)
 
     # setup figure
     fig = Figure()
-    ax = Axis3(
-        fig[1,1], 
-        azimuth = π/4, 
-        title=orth(irfs) ? "Orthogonal Impulse Response Function" : "Impulse Response Function",
-        titlealign=:left,
-        titlecolor=:gray50,
-        xlabel="time",
-        ylabel="periods",
-        yticks=(0:periods, ["$h" for h = 0:periods])
-    )
+    ax = Axis3(fig[1, 1],
+               azimuth = π / 4,
+               title = orth(irfs) ? "Orthogonal Impulse Response Function" :
+                       "Impulse Response Function",
+               titlealign = :left,
+               titlecolor = :gray50,
+               xlabel = "time",
+               ylabel = "periods",
+               yticks = (0:periods, ["$h" for h in 0:periods]))
 
     # impulse response function
     surface!(ax, 1:time, 0:periods, ψ')
@@ -421,16 +414,15 @@ function irf_plot(irfs::DynamicIRF, impulse, response, time)
 
     # setup figure
     fig = Figure()
-    ax = Axis3(
-        fig[1,1], 
-        azimuth = π/4, 
-        title=orth(irfs) ? "Orthogonal Impulse Response Function" : "Impulse Response Function",
-        titlealign=:left,
-        titlecolor=:gray50,
-        xlabel="time",
-        ylabel="periods",
-        yticks=(0:periods, ["$h" for h = 0:periods])
-    )
+    ax = Axis3(fig[1, 1],
+               azimuth = π / 4,
+               title = orth(irfs) ? "Orthogonal Impulse Response Function" :
+                       "Impulse Response Function",
+               titlealign = :left,
+               titlecolor = :gray50,
+               xlabel = "time",
+               ylabel = "periods",
+               yticks = (0:periods, ["$h" for h in 0:periods]))
 
     # impulse response function
     surface!(ax, time, 0:periods, ψ')
@@ -444,21 +436,22 @@ function irf_plot(irfs::DynamicIRF, impulse, response, time::Integer)
 
     # setup figure
     fig = Figure()
-    ax = Axis(
-        fig[1,1], 
-        title=orth(irfs) ? "Orthogonal Impulse Response Function" : "Impulse Response Function",
-        titlealign=:left,
-        titlecolor=:gray50,
-        xlabel="periods",
-        xticks=(0:periods, ["$h" for h = 0:periods])
-    )
+    ax = Axis(fig[1, 1],
+              title = orth(irfs) ? "Orthogonal Impulse Response Function" :
+                      "Impulse Response Function",
+              titlealign = :left,
+              titlecolor = :gray50,
+              xlabel = "periods",
+              xticks = (0:periods, ["$h" for h in 0:periods]))
 
     # impulse response function
-    lines!(ax, 0:periods, ψ, color=:black)
+    lines!(ax, 0:periods, ψ, color = :black)
 
     # confidence bands
-    lines!(ax, 0:periods, lower(irfs, impulse, response, time), color=:gray50, linestyle=:dash)
-    lines!(ax, 0:periods, upper(irfs, impulse, response, time), color=:gray50, linestyle=:dash)
+    lines!(ax, 0:periods, lower(irfs, impulse, response, time),
+           color = :gray50, linestyle = :dash)
+    lines!(ax, 0:periods, upper(irfs, impulse, response, time),
+           color = :gray50, linestyle = :dash)
 
     return fig
 end

--- a/src/plotting.jl
+++ b/src/plotting.jl
@@ -1,10 +1,9 @@
 #=
 plotting.jl
 
-    Provides a collection of visualization methods for tensor autoregressive 
-    models, such as impulse response functions, forecasts, data plots, and 
-    Kruskal coefficient tensor and tensor error covariance structure 
-    visualization.
+    Provides a collection of visualization methods for tensor autoregressive models, such as
+    impulse response functions, forecasts, data plots, and Kruskal coefficient tensor and
+    tensor error covariance structure visualization.
 
 @author: Quint Wiersma <q.wiersma@vu.nl>
 
@@ -58,14 +57,11 @@ function data_plot(model::AbstractTensorAutoregression)
     colors = resample_cmap(:viridis, prod(dims[m]))
     for (idx, ax) in pairs(IndexCartesian(), axs)
         y = selectdim(data(model), maxmode, idx[1])
-        series!(ax,
-                reshape(selectdim(y, n - 1, idx[2]), :, last(dims)),
-                color = colors)
+        series!(ax, reshape(selectdim(y, n - 1, idx[2]), :, last(dims)), color = colors)
     end
 
     return fig
 end
-
 function data_plot(model::AbstractTensorAutoregression, labels, time)
     dims = size(data(model))
     n = ndims(data(model)) - 1
@@ -116,10 +112,7 @@ function data_plot(model::AbstractTensorAutoregression, labels, time)
 
     # grid titles
     for (i, grid) in pairs(grids)
-        Label(grid[1, :, Top()],
-              labels[maxmode][i],
-              valign = :bottom,
-              font = :bold)
+        Label(grid[1, :, Top()], labels[maxmode][i], valign = :bottom, font = :bold)
     end
     # axis titles
     for grid in grids[(end - rows + 1):end]
@@ -134,9 +127,7 @@ function data_plot(model::AbstractTensorAutoregression, labels, time)
     colors = resample_cmap(:viridis, prod(dims[m]))
     for (idx, ax) in pairs(IndexCartesian(), axs)
         y = selectdim(data(model), maxmode, idx[1])
-        series!(ax,
-                reshape(selectdim(y, n - 1, idx[2]), :, last(dims)),
-                color = colors,
+        series!(ax, reshape(selectdim(y, n - 1, idx[2]), :, last(dims)), color = colors,
                 labels = sub_labels)
     end
 
@@ -144,11 +135,7 @@ function data_plot(model::AbstractTensorAutoregression, labels, time)
     if dims[maxmode] == length(indices)
         Legend(fig[:, cols + 1], axs[1], "sectors")
     else
-        Legend(fig[rows, cols],
-               axs[1],
-               "sectors",
-               tellwidth = false,
-               halign = :left)
+        Legend(fig[rows, cols], axs[1], "sectors", tellwidth = false, halign = :left)
     end
 
     return fig
@@ -157,8 +144,8 @@ end
 """
     kruskal_plot(A[, labels, time]) -> figs
 
-Plot factors and loadings of the Kruskal coefficient tensor `A` with optionally
-specified `labels` and `time`.
+Plot factors and loadings of the Kruskal coefficient tensor `A` with optionally specified
+`labels` and `time`.
 """
 function kruskal_plot(A::StaticKruskal)
     dims = size(A)
@@ -174,7 +161,6 @@ function kruskal_plot(A::StaticKruskal)
 
     return fig
 end
-
 function kruskal_plot(A::StaticKruskal, labels)
     dims = size(A)
     n = length(dims) ÷ 2
@@ -205,7 +191,6 @@ function kruskal_plot(A::StaticKruskal, labels)
 
     return fig
 end
-
 function kruskal_plot(A::DynamicKruskal)
     dims = size(A)
     n = length(dims) ÷ 2
@@ -223,7 +208,6 @@ function kruskal_plot(A::DynamicKruskal)
 
     return figs
 end
-
 function kruskal_plot(A::DynamicKruskal, labels, time)
     dims = size(A)
     n = length(dims) ÷ 2
@@ -267,8 +251,7 @@ end
 """
     cov_plot(ε[, labels]) -> fig
 
-Plot the tensor error covariance structure `ε` with optionally specified
-`labels`.
+Plot the tensor error covariance structure `ε` with optionally specified `labels`.
 """
 function cov_plot(ε::AbstractTensorErrorDistribution)
     # setup figure
@@ -281,7 +264,6 @@ function cov_plot(ε::AbstractTensorErrorDistribution)
 
     return fig
 end
-
 function cov_plot(ε::AbstractTensorErrorDistribution, labels)
     dims = size.(cov(ε), 1)
     n = length(dims)
@@ -316,9 +298,8 @@ end
 """
     nested_labels!(grid, dims, n, i, labels, loc)
 
-Add recursively nested `i`-th label from `n`nd level from `labels` to a grid
-layout `grid` with dimensions `dims` for the levels and `loc` indicating the
-location of the labels.
+Add recursively nested `i`-th label from `n`nd level from `labels` to a grid layout `grid`
+with dimensions `dims` for the levels and `loc` indicating the location of the labels.
 """
 function nested_labels!(grid, dims, n, i, labels, loc)
     # terminate at final to last level (last level are axis ticks)
@@ -355,9 +336,9 @@ end
 """
     irf_plot(irfs, impulse, response[, time]) -> fig
 
-Plot the impulse response function `irfs` for the response `response` to the
-impulse `impulse`. When `irfs` is dynamic `time` can be provided to plot the
-impulse response function for a specific time period.
+Plot the impulse response function `irfs` for the response `response` to the impulse
+`impulse`. When `irfs` is dynamic `time` can be provided to plot the impulse response
+function for a specific time period.
 """
 function irf_plot(irfs::StaticIRF, impulse, response)
     ψ = irf(irfs, impulse, response)
@@ -367,11 +348,8 @@ function irf_plot(irfs::StaticIRF, impulse, response)
     fig = Figure()
     ax = Axis(fig[1, 1],
               title = orth(irfs) ? "Orthogonal Impulse Response Function" :
-                      "Impulse Response Function",
-              titlealign = :left,
-              titlecolor = :gray50,
-              xlabel = "periods",
-              xticks = (0:periods, ["$h" for h in 0:periods]))
+                      "Impulse Response Function", titlealign = :left, titlecolor = :gray50,
+              xlabel = "periods", xticks = (0:periods, ["$h" for h in 0:periods]))
 
     # impulse response function
     lines!(ax, 0:periods, ψ, color = :black)
@@ -384,7 +362,6 @@ function irf_plot(irfs::StaticIRF, impulse, response)
 
     return fig
 end
-
 function irf_plot(irfs::DynamicIRF, impulse, response)
     ψ = irf(irfs, impulse, response)
     periods = size(ψ, 1) - 1
@@ -392,14 +369,10 @@ function irf_plot(irfs::DynamicIRF, impulse, response)
 
     # setup figure
     fig = Figure()
-    ax = Axis3(fig[1, 1],
-               azimuth = π / 4,
+    ax = Axis3(fig[1, 1], azimuth = π / 4,
                title = orth(irfs) ? "Orthogonal Impulse Response Function" :
-                       "Impulse Response Function",
-               titlealign = :left,
-               titlecolor = :gray50,
-               xlabel = "time",
-               ylabel = "periods",
+                       "Impulse Response Function", titlealign = :left,
+               titlecolor = :gray50, xlabel = "time", ylabel = "periods",
                yticks = (0:periods, ["$h" for h in 0:periods]))
 
     # impulse response function
@@ -407,21 +380,16 @@ function irf_plot(irfs::DynamicIRF, impulse, response)
 
     return fig
 end
-
 function irf_plot(irfs::DynamicIRF, impulse, response, time)
     ψ = irf(irfs, impulse, response, time)
     periods = size(ψ, 1) - 1
 
     # setup figure
     fig = Figure()
-    ax = Axis3(fig[1, 1],
-               azimuth = π / 4,
+    ax = Axis3(fig[1, 1], azimuth = π / 4,
                title = orth(irfs) ? "Orthogonal Impulse Response Function" :
-                       "Impulse Response Function",
-               titlealign = :left,
-               titlecolor = :gray50,
-               xlabel = "time",
-               ylabel = "periods",
+                       "Impulse Response Function", titlealign = :left,
+               titlecolor = :gray50, xlabel = "time", ylabel = "periods",
                yticks = (0:periods, ["$h" for h in 0:periods]))
 
     # impulse response function
@@ -429,7 +397,6 @@ function irf_plot(irfs::DynamicIRF, impulse, response, time)
 
     return fig
 end
-
 function irf_plot(irfs::DynamicIRF, impulse, response, time::Integer)
     ψ = irf(irfs, impulse, response, time)
     periods = length(ψ) - 1
@@ -438,11 +405,8 @@ function irf_plot(irfs::DynamicIRF, impulse, response, time::Integer)
     fig = Figure()
     ax = Axis(fig[1, 1],
               title = orth(irfs) ? "Orthogonal Impulse Response Function" :
-                      "Impulse Response Function",
-              titlealign = :left,
-              titlecolor = :gray50,
-              xlabel = "periods",
-              xticks = (0:periods, ["$h" for h in 0:periods]))
+                      "Impulse Response Function", titlealign = :left, titlecolor = :gray50,
+              xlabel = "periods", xticks = (0:periods, ["$h" for h in 0:periods]))
 
     # impulse response function
     lines!(ax, 0:periods, ψ, color = :black)

--- a/src/tensor_algebra.jl
+++ b/src/tensor_algebra.jl
@@ -18,7 +18,7 @@ function matricize(A::AbstractArray, n)
     m = setdiff(1:ndims(A), n)
     perm = [n; m]
 
-    return reshape(permutedims(A, perm), prod(dims[n]), prod(dims[m])) 
+    return reshape(permutedims(A, perm), prod(dims[n]), prod(dims[m]))
 end
 
 """
@@ -40,7 +40,7 @@ Tucker operator along modes `n` of tensor `G` with matrices `A`.
 """
 function tucker(G::AbstractArray, A::AbstractVector, n)
     dims = collect(size(G))
-    for (i, k) ∈ enumerate(n)
+    for (i, k) in enumerate(n)
         Gk = matricize(G, k)
         dims[k] = size(A[i], 1)
         G = tensorize(A[i] * Gk, k, dims)
@@ -56,8 +56,8 @@ tucker(G::AbstractArray, A::AbstractVector) = tucker(G, A, 1:length(A))
 Identity tensor of `n` modes with mode size `R`.
 """
 function (I::UniformScaling)(n::Integer, R::Integer)
-    Id = zeros((R for _ = 1:n)...)
-    for i = 1:R
+    Id = zeros((R for _ in 1:n)...)
+    for i in 1:R
         Id[repeat([i], n)...] = one(Float64)
     end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,10 +1,9 @@
 #=
 types.jl
 
-    Provides a collection of types for working with tensor autoregressive
-    models, such as the Kruskal tensor for the autoregressive coefficients and
-    tensor error distributions, as well as the main tensor autoregressive model
-    itself.
+    Provides a collection of types for working with tensor autoregressive models, such as
+    the Kruskal tensor for the autoregressive coefficients and tensor error distributions,
+    as well as the main tensor autoregressive model itself.
 
 @author: Quint Wiersma <q.wiersma@vu.nl>
 
@@ -24,8 +23,7 @@ abstract type AbstractKruskal end
 
 Static Kruskal tensor of rank `R` with loadings `λ` and factor matrices `U`.
 """
-struct StaticKruskal{Tλ <: AbstractVector,
-                     TU <: AbstractVector} <: AbstractKruskal
+struct StaticKruskal{Tλ <: AbstractVector, TU <: AbstractVector} <: AbstractKruskal
     λ::Tλ
     U::TU
     R::Int
@@ -45,23 +43,16 @@ end
 Dynamic Kruskal tensor of rank `R` with dynamic loadings `λ` and factor matrices
 `U`.
 """
-struct DynamicKruskal{Tλ <: AbstractMatrix,
-                      Tα <: AbstractVector,
-                      Tϕ <: Diagonal,
-                      TΣ <: Diagonal,
-                      TU <: AbstractVector} <: AbstractKruskal
+struct DynamicKruskal{Tλ <: AbstractMatrix, Tα <: AbstractVector, Tϕ <: Diagonal,
+                      TΣ <: Diagonal, TU <: AbstractVector} <: AbstractKruskal
     λ::Tλ
     α::Tα
     ϕ::Tϕ
     Σ::TΣ
     U::TU
     R::Int
-    function DynamicKruskal(λ::AbstractMatrix,
-                            α::AbstractVector,
-                            ϕ::Diagonal,
-                            Σ::Diagonal,
-                            U::AbstractVector,
-                            R::Integer)
+    function DynamicKruskal(λ::AbstractMatrix, α::AbstractVector, ϕ::Diagonal, Σ::Diagonal,
+                            U::AbstractVector, R::Integer)
         length(α) == R || error("α must be a vector of length R.")
         size(ϕ, 1) == R || error("ϕ must be a diagonal matrix of rank R.")
         size(Σ, 1) == R || error("Σ must be a diagonal matrix of rank R.")
@@ -126,11 +117,9 @@ abstract type AbstractTensorErrorDistribution end
 """
     WhiteNoise <: AbstractTensorErrorDistribution
 
-White noise model of tensor errors `ε` with covariance matrix `Σ` of
-``vec(ε)``.
+White noise model of tensor errors `ε` with covariance matrix `Σ` of ``vec(ε)``.
 """
-struct WhiteNoise{Tε <: AbstractArray,
-                  TΣ <: Symmetric} <: AbstractTensorErrorDistribution
+struct WhiteNoise{Tε <: AbstractArray, TΣ <: Symmetric} <: AbstractTensorErrorDistribution
     ε::Tε
     Σ::Symmetric
     function WhiteNoise(ε::AbstractArray, Σ::Symmetric)
@@ -144,11 +133,11 @@ end
 """
     TensorNormal <: AbstractTensorErrorDistribution
 
-Tensor normal model of tensor errors `ε` with separable covariance matrix
-`Σ` along each mode of the tensor.
+Tensor normal model of tensor errors `ε` with separable covariance matrix `Σ` along each
+mode of the tensor.
 """
-struct TensorNormal{Tε <: AbstractArray,
-                    TΣ <: AbstractVector} <: AbstractTensorErrorDistribution
+struct TensorNormal{Tε <: AbstractArray, TΣ <: AbstractVector} <:
+       AbstractTensorErrorDistribution
     ε::Tε
     Σ::TΣ
     function TensorNormal(ε::AbstractArray, Σ::AbstractVector)
@@ -203,8 +192,8 @@ abstract type AbstractTensorAutoregression <: StatisticalModel end
 """
     StaticTensorAutoregression <: AbstractTensorAutoregression
 
-Tensor autoregressive model with tensor error distribution `ε` and static
-Kruskal tensor representation `A`.
+Tensor autoregressive model with tensor error distribution `ε` and static Kruskal tensor
+representation `A`.
 """
 struct StaticTensorAutoregression{Ty <: AbstractArray,
                                   Tε <: AbstractTensorErrorDistribution,
@@ -229,8 +218,8 @@ end
 """
     DynamicTensorAutoregression <: AbstractTensorAutoregression
 
-Tensor autoregressive model with tensor error distribution `ε` and dynamic
-Kruskal tensor representation `A`.
+Tensor autoregressive model with tensor error distribution `ε` and dynamic Kruskal tensor
+representation `A`.
 """
 struct DynamicTensorAutoregression{Ty <: AbstractArray,
                                    Tε <: AbstractTensorErrorDistribution,
@@ -293,9 +282,9 @@ abstract type AbstractIRF end
 """
     StaticIRF <: AbstractIRF
 
-Static impulse response function (IRF) with `Ψ` as the IRF matrix, `lower` and
-`upper` as the lower and upper bounds of the ``α``% confidence interval, and
-`orth` as whether the IRF is orthogonalized.
+Static impulse response function (IRF) with `Ψ` as the IRF matrix, `lower` and `upper` as
+the lower and upper bounds of the ``α``% confidence interval, and `orth` as whether the IRF
+is orthogonalized.
 """
 struct StaticIRF{TΨ <: AbstractArray} <: AbstractIRF
     Ψ::TΨ
@@ -311,9 +300,9 @@ end
 """
     DynamicIRF <: AbstractIRF
 
-Dynamic impulse response function (IRF) with `Ψ` as the IRF matrix, `lower` and
-`upper` as the lower and upper bounds of the ``α``% confidence interval, and
-`orth` as whether the IRF is orthogonalized.
+Dynamic impulse response function (IRF) with `Ψ` as the IRF matrix, `lower` and `upper` as
+the lower and upper bounds of the ``α``% confidence interval, and `orth` as whether the IRF
+is orthogonalized.
 """
 struct DynamicIRF{TΨ <: AbstractArray} <: AbstractIRF
     Ψ::TΨ

--- a/src/types.jl
+++ b/src/types.jl
@@ -24,7 +24,7 @@ abstract type AbstractKruskal end
 
 Static Kruskal tensor of rank `R` with loadings `λ` and factor matrices `U`.
 """
-mutable struct StaticKruskal{
+struct StaticKruskal{
     Tλ<:AbstractVector, 
     TU<:AbstractVector
 } <: AbstractKruskal
@@ -45,7 +45,7 @@ end
 Dynamic Kruskal tensor of rank `R` with dynamic loadings `λ` and factor matrices
 `U`. 
 """
-mutable struct DynamicKruskal{
+struct DynamicKruskal{
     Tλ<:AbstractMatrix,
     Tα<:AbstractVector,
     Tϕ<:Diagonal,
@@ -123,7 +123,7 @@ abstract type AbstractTensorErrorDistribution end
 White noise model of tensor errors `ε` with covariance matrix `Σ` of
 ``vec(ε)``.
 """
-mutable struct WhiteNoise{
+struct WhiteNoise{
     Tε<:AbstractArray,
     TΣ<:Symmetric
 } <: AbstractTensorErrorDistribution
@@ -142,7 +142,7 @@ end
 Tensor normal model of tensor errors `ε` with separable covariance matrix
 `Σ` along each mode of the tensor.
 """
-mutable struct TensorNormal{
+struct TensorNormal{
     Tε<:AbstractArray,
     TΣ<:AbstractVector
 } <: AbstractTensorErrorDistribution
@@ -202,7 +202,7 @@ abstract type AbstractTensorAutoregression <: StatisticalModel end
 Tensor autoregressive model with tensor error distribution `ε` and static
 Kruskal tensor representation `A`.
 """
-mutable struct StaticTensorAutoregression{
+struct StaticTensorAutoregression{
     Ty<:AbstractArray, 
     Tε<:AbstractTensorErrorDistribution,
     TA<:StaticKruskal,
@@ -233,7 +233,7 @@ end
 Tensor autoregressive model with tensor error distribution `ε` and dynamic
 Kruskal tensor representation `A`.
 """
-mutable struct DynamicTensorAutoregression{
+struct DynamicTensorAutoregression{
     Ty<:AbstractArray, 
     Tε<:AbstractTensorErrorDistribution,
     TA<:DynamicKruskal,
@@ -298,7 +298,7 @@ Static impulse response function (IRF) with `Ψ` as the IRF matrix, `lower` and
 `upper` as the lower and upper bounds of the ``α``% confidence interval, and
 `orth` as whether the IRF is orthogonalized.
 """
-mutable struct StaticIRF{TΨ<:AbstractArray} <: AbstractIRF
+struct StaticIRF{TΨ<:AbstractArray} <: AbstractIRF
     Ψ::TΨ
     lower::TΨ
     upper::TΨ
@@ -315,7 +315,7 @@ Dynamic impulse response function (IRF) with `Ψ` as the IRF matrix, `lower` and
 `upper` as the lower and upper bounds of the ``α``% confidence interval, and
 `orth` as whether the IRF is orthogonalized.
 """
-mutable struct DynamicIRF{TΨ<:AbstractArray} <: AbstractIRF
+struct DynamicIRF{TΨ<:AbstractArray} <: AbstractIRF
     Ψ::TΨ
     lower::TΨ
     upper::TΨ

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,10 +1,10 @@
 #=
 types.jl
 
-    Provides a collection of types for working with tensor autoregressive 
-    models, such as the Kruskal tensor for the autoregressive coefficients and 
-    tensor error distributions, as well as the main tensor autoregressive model 
-    itself. 
+    Provides a collection of types for working with tensor autoregressive
+    models, such as the Kruskal tensor for the autoregressive coefficients and
+    tensor error distributions, as well as the main tensor autoregressive model
+    itself.
 
 @author: Quint Wiersma <q.wiersma@vu.nl>
 
@@ -24,16 +24,16 @@ abstract type AbstractKruskal end
 
 Static Kruskal tensor of rank `R` with loadings `λ` and factor matrices `U`.
 """
-struct StaticKruskal{
-    Tλ<:AbstractVector, 
-    TU<:AbstractVector
-} <: AbstractKruskal
+struct StaticKruskal{Tλ <: AbstractVector,
+                     TU <: AbstractVector} <: AbstractKruskal
     λ::Tλ
     U::TU
     R::Int
     function StaticKruskal(λ::AbstractVector, U::AbstractVector, R::Integer)
-        length(unique(size.(U, 2))) == 1 || throw(DimensionMismatch("all factor matrices must have the same number of columns."))
-        length(λ) == size(U[1], 2) == R || throw(DimensionMismatch("number of loadings and number of columns of factor matrices must equal rank R."))
+        length(unique(size.(U, 2))) == 1 ||
+            throw(DimensionMismatch("all factor matrices must have the same number of columns."))
+        length(λ) == size(U[1], 2) == R ||
+            throw(DimensionMismatch("number of loadings and number of columns of factor matrices must equal rank R."))
 
         return new{typeof(λ), typeof(U)}(λ, U, R)
     end
@@ -43,34 +43,32 @@ end
     DynamicKruskal <: AbstractKruskal
 
 Dynamic Kruskal tensor of rank `R` with dynamic loadings `λ` and factor matrices
-`U`. 
+`U`.
 """
-struct DynamicKruskal{
-    Tλ<:AbstractMatrix,
-    Tα<:AbstractVector,
-    Tϕ<:Diagonal,
-    TΣ<:Diagonal,
-    TU<:AbstractVector
-} <: AbstractKruskal
+struct DynamicKruskal{Tλ <: AbstractMatrix,
+                      Tα <: AbstractVector,
+                      Tϕ <: Diagonal,
+                      TΣ <: Diagonal,
+                      TU <: AbstractVector} <: AbstractKruskal
     λ::Tλ
     α::Tα
     ϕ::Tϕ
     Σ::TΣ
     U::TU
     R::Int
-    function DynamicKruskal(
-        λ::AbstractMatrix,
-        α::AbstractVector,
-        ϕ::Diagonal, 
-        Σ::Diagonal, 
-        U::AbstractVector, 
-        R::Integer
-    )
+    function DynamicKruskal(λ::AbstractMatrix,
+                            α::AbstractVector,
+                            ϕ::Diagonal,
+                            Σ::Diagonal,
+                            U::AbstractVector,
+                            R::Integer)
         length(α) == R || error("α must be a vector of length R.")
         size(ϕ, 1) == R || error("ϕ must be a diagonal matrix of rank R.")
         size(Σ, 1) == R || error("Σ must be a diagonal matrix of rank R.")
-        length(unique(size.(U, 2))) == 1 || throw(DimensionMismatch("all factor matrices must have the same number of columns."))
-        size(λ, 1) == size(U[1], 2) == R || throw(DimensionMismatch("number of loadings and number of columns of factor matrices must equal rank R."))
+        length(unique(size.(U, 2))) == 1 ||
+            throw(DimensionMismatch("all factor matrices must have the same number of columns."))
+        size(λ, 1) == size(U[1], 2) == R ||
+            throw(DimensionMismatch("number of loadings and number of columns of factor matrices must equal rank R."))
 
         return new{typeof(λ), typeof(α), typeof(ϕ), typeof(Σ), typeof(U)}(λ, α, ϕ, Σ, U, R)
     end
@@ -89,8 +87,13 @@ dynamics(A::DynamicKruskal) = A.ϕ
 cov(A::DynamicKruskal) = A.Σ
 dof(A::StaticKruskal) = rank(A) + sum(length, factors(A))
 dof(A::DynamicKruskal) = 3 * rank(A) + sum(length, factors(A))
-Base.similar(A::StaticKruskal) = StaticKruskal(similar(loadings(A)), similar.(factors(A)), rank(A))
-Base.similar(A::DynamicKruskal) = DynamicKruskal(similar(loadings(A)), similar(intercept(A)), similar(dynamics(A)), similar(cov(A)), similar.(factors(A)), rank(A))
+function Base.similar(A::StaticKruskal)
+    StaticKruskal(similar(loadings(A)), similar.(factors(A)), rank(A))
+end
+function Base.similar(A::DynamicKruskal)
+    DynamicKruskal(similar(loadings(A)), similar(intercept(A)), similar(dynamics(A)),
+                   similar(cov(A)), similar.(factors(A)), rank(A))
+end
 function Base.copyto!(dest::StaticKruskal, src::StaticKruskal)
     copyto!(loadings(dest), loadings(src))
     copyto!.(factors(dest), factors(src))
@@ -123,14 +126,13 @@ abstract type AbstractTensorErrorDistribution end
 White noise model of tensor errors `ε` with covariance matrix `Σ` of
 ``vec(ε)``.
 """
-struct WhiteNoise{
-    Tε<:AbstractArray,
-    TΣ<:Symmetric
-} <: AbstractTensorErrorDistribution
+struct WhiteNoise{Tε <: AbstractArray,
+                  TΣ <: Symmetric} <: AbstractTensorErrorDistribution
     ε::Tε
     Σ::Symmetric
     function WhiteNoise(ε::AbstractArray, Σ::Symmetric)
-        prod(size(ε)[1:end-1]) == size(Σ, 1) || throw(DimensionMismatch("number of elements in vec(εₜ) must equal rank of Σ."))
+        prod(size(ε)[1:(end - 1)]) == size(Σ, 1) ||
+            throw(DimensionMismatch("number of elements in vec(εₜ) must equal rank of Σ."))
 
         return new{typeof(ε), typeof(Σ)}(ε, Σ)
     end
@@ -142,15 +144,15 @@ end
 Tensor normal model of tensor errors `ε` with separable covariance matrix
 `Σ` along each mode of the tensor.
 """
-struct TensorNormal{
-    Tε<:AbstractArray,
-    TΣ<:AbstractVector
-} <: AbstractTensorErrorDistribution
+struct TensorNormal{Tε <: AbstractArray,
+                    TΣ <: AbstractVector} <: AbstractTensorErrorDistribution
     ε::Tε
     Σ::TΣ
     function TensorNormal(ε::AbstractArray, Σ::AbstractVector)
-        length(Σ) == ndims(ε) - 1 || error("number of matrices in Σ must equal number of modes of εₜ.")
-        all(size.(Σ, 1) .== size(ε)[1:end-1]) || throw(DimensionMismatch("dimensions of matrices in Σ must equal dimensions of modes of εₜ."))
+        length(Σ) == ndims(ε) - 1 ||
+            error("number of matrices in Σ must equal number of modes of εₜ.")
+        all(size.(Σ, 1) .== size(ε)[1:(end - 1)]) ||
+            throw(DimensionMismatch("dimensions of matrices in Σ must equal dimensions of modes of εₜ."))
         all(issymmetric, Σ) || error("all matrices in Σ must be symmetric.")
 
         return new{typeof(ε), typeof(Σ)}(ε, Symmetric.(Σ))
@@ -159,11 +161,11 @@ end
 
 # methods
 resid(ε::AbstractTensorErrorDistribution) = ε.ε
-cov(ε::AbstractTensorErrorDistribution; full::Bool=false) = ε.Σ
-function cov(ε::TensorNormal; full::Bool=false)
+cov(ε::AbstractTensorErrorDistribution; full::Bool = false) = ε.Σ
+function cov(ε::TensorNormal; full::Bool = false)
     if full
         Σ = cov(ε)[end]
-        for Σi ∈ reverse(cov(ε)[1:end-1])
+        for Σi in reverse(cov(ε)[1:(end - 1)])
             Σ = kron(Σ, Σi)
         end
         return Σ
@@ -201,23 +203,21 @@ abstract type AbstractTensorAutoregression <: StatisticalModel end
 Tensor autoregressive model with tensor error distribution `ε` and static
 Kruskal tensor representation `A`.
 """
-struct StaticTensorAutoregression{
-    Ty<:AbstractArray, 
-    Tε<:AbstractTensorErrorDistribution,
-    TA<:StaticKruskal
-} <: AbstractTensorAutoregression
+struct StaticTensorAutoregression{Ty <: AbstractArray,
+                                  Tε <: AbstractTensorErrorDistribution,
+                                  TA <: StaticKruskal} <: AbstractTensorAutoregression
     y::Ty
     ε::Tε
     A::TA
-    function StaticTensorAutoregression(
-        y::AbstractArray, 
-        ε::AbstractTensorErrorDistribution, 
-        A::StaticKruskal
-    )
+    function StaticTensorAutoregression(y::AbstractArray,
+                                        ε::AbstractTensorErrorDistribution,
+                                        A::StaticKruskal)
         dims = size(y)
         n = ndims(y) - 1
-        size(y)[1:n] == size(resid(ε))[1:n] || throw(DimensionMismatch("dimensions of y and residuals must be equal."))
-        all((dims[1:n]..., dims[1:n]...) .== size.(factors(A), 1)) || throw(DimensionMismatch("dimensions of loadings must equal number of columns of y."))
+        size(y)[1:n] == size(resid(ε))[1:n] ||
+            throw(DimensionMismatch("dimensions of y and residuals must be equal."))
+        all((dims[1:n]..., dims[1:n]...) .== size.(factors(A), 1)) ||
+            throw(DimensionMismatch("dimensions of loadings must equal number of columns of y."))
 
         return new{typeof(y), typeof(ε), typeof(A)}(y, ε, A)
     end
@@ -229,24 +229,23 @@ end
 Tensor autoregressive model with tensor error distribution `ε` and dynamic
 Kruskal tensor representation `A`.
 """
-struct DynamicTensorAutoregression{
-    Ty<:AbstractArray, 
-    Tε<:AbstractTensorErrorDistribution,
-    TA<:DynamicKruskal
-} <: AbstractTensorAutoregression
+struct DynamicTensorAutoregression{Ty <: AbstractArray,
+                                   Tε <: AbstractTensorErrorDistribution,
+                                   TA <: DynamicKruskal} <: AbstractTensorAutoregression
     y::Ty
     ε::Tε
     A::TA
-    function DynamicTensorAutoregression(
-        y::AbstractArray, 
-        ε::AbstractTensorErrorDistribution, 
-        A::DynamicKruskal
-    )
+    function DynamicTensorAutoregression(y::AbstractArray,
+                                         ε::AbstractTensorErrorDistribution,
+                                         A::DynamicKruskal)
         dims = size(y)
         n = ndims(y) - 1
-        size(y)[1:n] == size(resid(ε))[1:n] || throw(DimensionMismatch("dimensions of y and residuals must be equal."))
-        all((dims[1:n]..., dims[1:n]...) .== size.(factors(A), 1)) || throw(DimensionMismatch("dimensions of loadings must equal number of columns of y."))
-        ε isa WhiteNoise && throw(ArgumentError("dynamic model with white noise error not supported."))
+        size(y)[1:n] == size(resid(ε))[1:n] ||
+            throw(DimensionMismatch("dimensions of y and residuals must be equal."))
+        all((dims[1:n]..., dims[1:n]...) .== size.(factors(A), 1)) ||
+            throw(DimensionMismatch("dimensions of loadings must equal number of columns of y."))
+        ε isa WhiteNoise &&
+            throw(ArgumentError("dynamic model with white noise error not supported."))
 
         return new{typeof(y), typeof(ε), typeof(A)}(y, ε, A)
     end
@@ -257,14 +256,20 @@ data(model::AbstractTensorAutoregression) = model.y
 coef(model::AbstractTensorAutoregression) = model.A
 dist(model::AbstractTensorAutoregression) = model.ε
 resid(model::AbstractTensorAutoregression) = resid(dist(model))
-cov(model::AbstractTensorAutoregression; full::Bool=false) = cov(dist(model), full=full)
+cov(model::AbstractTensorAutoregression; full::Bool = false) = cov(dist(model), full = full)
 factors(model::AbstractTensorAutoregression) = factors(coef(model))
 loadings(model::AbstractTensorAutoregression) = loadings(coef(model))
 rank(model::AbstractTensorAutoregression) = rank(coef(model))
 nobs(model::AbstractTensorAutoregression) = last(size(data(model)))
 dof(model::AbstractTensorAutoregression) = dof(coef(model)) + dof(dist(model))
-Base.similar(model::StaticTensorAutoregression) = StaticTensorAutoregression(similar(data(model)), similar(dist(model)), similar(coef(model)))
-Base.similar(model::DynamicTensorAutoregression) = DynamicTensorAutoregression(similar(data(model)), similar(dist(model)), similar(coef(model)))
+function Base.similar(model::StaticTensorAutoregression)
+    StaticTensorAutoregression(similar(data(model)), similar(dist(model)),
+                               similar(coef(model)))
+end
+function Base.similar(model::DynamicTensorAutoregression)
+    DynamicTensorAutoregression(similar(data(model)), similar(dist(model)),
+                                similar(coef(model)))
+end
 function Base.copyto!(dest::AbstractTensorAutoregression, src::AbstractTensorAutoregression)
     copyto!(data(dest), data(src))
     copyto!(dist(dest), dist(src))
@@ -289,12 +294,13 @@ Static impulse response function (IRF) with `Ψ` as the IRF matrix, `lower` and
 `upper` as the lower and upper bounds of the ``α``% confidence interval, and
 `orth` as whether the IRF is orthogonalized.
 """
-struct StaticIRF{TΨ<:AbstractArray} <: AbstractIRF
+struct StaticIRF{TΨ <: AbstractArray} <: AbstractIRF
     Ψ::TΨ
     lower::TΨ
     upper::TΨ
     orth::Bool
-    function StaticIRF(Ψ::AbstractArray, lower::AbstractArray, upper::AbstractArray, orth::Bool)
+    function StaticIRF(Ψ::AbstractArray, lower::AbstractArray, upper::AbstractArray,
+                       orth::Bool)
         return new{typeof(Ψ)}(Ψ, lower, upper, orth)
     end
 end
@@ -306,12 +312,13 @@ Dynamic impulse response function (IRF) with `Ψ` as the IRF matrix, `lower` and
 `upper` as the lower and upper bounds of the ``α``% confidence interval, and
 `orth` as whether the IRF is orthogonalized.
 """
-struct DynamicIRF{TΨ<:AbstractArray} <: AbstractIRF
+struct DynamicIRF{TΨ <: AbstractArray} <: AbstractIRF
     Ψ::TΨ
     lower::TΨ
     upper::TΨ
     orth::Bool
-    function DynamicIRF(Ψ::AbstractArray, lower::AbstractArray, upper::AbstractArray, orth::Bool)
+    function DynamicIRF(Ψ::AbstractArray, lower::AbstractArray, upper::AbstractArray,
+                        orth::Bool)
         return new{typeof(Ψ)}(Ψ, lower, upper, orth)
     end
 end
@@ -320,13 +327,23 @@ end
 irf(irfs::AbstractIRF) = irfs.Ψ
 irf(irfs::StaticIRF, impulse, response) = @view irf(irfs)[impulse..., response..., :]
 irf(irfs::DynamicIRF, impulse, response) = @view irf(irfs)[impulse..., response..., :, :]
-irf(irfs::DynamicIRF, impulse, response, time) = @view irf(irfs)[impulse..., response..., :, time]
+function irf(irfs::DynamicIRF, impulse, response, time)
+    @view irf(irfs)[impulse..., response..., :, time]
+end
 lower(irfs::AbstractIRF) = irfs.lower
 lower(irfs::StaticIRF, impulse, response) = @view lower(irfs)[impulse..., response..., :]
-lower(irfs::DynamicIRF, impulse, response) = @view lower(irfs)[impulse..., response..., :, :]
-lower(irfs::DynamicIRF, impulse, response, time) = @view lower(irfs)[impulse..., response..., :, time]
+function lower(irfs::DynamicIRF, impulse, response)
+    @view lower(irfs)[impulse..., response..., :, :]
+end
+function lower(irfs::DynamicIRF, impulse, response, time)
+    @view lower(irfs)[impulse..., response..., :, time]
+end
 upper(irfs::AbstractIRF) = irfs.upper
 upper(irfs::StaticIRF, impulse, response) = @view upper(irfs)[impulse..., response..., :]
-upper(irfs::DynamicIRF, impulse, response) = @view upper(irfs)[impulse..., response..., :, :]
-upper(irfs::DynamicIRF, impulse, response, time) = @view upper(irfs)[impulse..., response..., :, time]
-orth(irfs::AbstractIRF) = irfs.orth 
+function upper(irfs::DynamicIRF, impulse, response)
+    @view upper(irfs)[impulse..., response..., :, :]
+end
+function upper(irfs::DynamicIRF, impulse, response, time)
+    @view upper(irfs)[impulse..., response..., :, time]
+end
+orth(irfs::AbstractIRF) = irfs.orth

--- a/src/types.jl
+++ b/src/types.jl
@@ -82,6 +82,9 @@ Base.size(A::AbstractKruskal) = tuple(size.(factors(A), 1)...)
 Base.size(A::DynamicKruskal) = tuple(size.(factors(A), 1)..., size(loadings(A), 2))
 full(A::AbstractKruskal) = tucker(loadings(A) .* I(length(factors(A)), rank(A)), factors(A))
 full(A::DynamicKruskal) = tucker(I(length(factors(A)), rank(A)), factors(A))
+function outer(A::AbstractKruskal)
+    [[factors(A)[i + n][:, r] * factors(A)[i][:, r]' for i in 1:n] for r in 1:rank(A)]
+end
 intercept(A::DynamicKruskal) = A.α
 dynamics(A::DynamicKruskal) = A.ϕ
 cov(A::DynamicKruskal) = A.Σ

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -155,16 +155,16 @@ function particle_sampler(model::DynamicTensorAutoregression, periods::Integer;
     (a, P, v, _, K) = filter(model)
     # predict
     if time == last(size(coef(model)))
-        â = T * a[end] + K[end] * v[end] + c
-        P̂ = T * P[end] * (T - K[end] * Z_star[end])' + Q
+        a_hat = T * a[end] + K[end] * v[end] + c
+        P_hat = T * P[end] * (T - K[end] * Z_star[end])' + Q
     elseif time < last(size(coef(model)))
-        â = a[time + 1]
-        P̂ = P[time + 1]
+        a_hat = a[time + 1]
+        P_hat = P[time + 1]
     end
 
     # particle sampling
-    particles = similar(â, length(â), samples, periods)
-    particles[:, :, 1] = rand(rng, MvNormal(â, P̂), samples)
+    particles = similar(a_hat, length(a_hat), samples, periods)
+    particles[:, :, 1] = rand(rng, MvNormal(a_hat, P_hat), samples)
     for h in 2:periods, s in 1:samples
         particles[:, s, h] = rand(rng, MvNormal(c + T * particles[:, s, h - 1], Q))
     end

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -1,10 +1,10 @@
 #=
 utilities.jl
 
-    Provides a collection of utility tools for working with tensor
-    autoregressive models, such as moving average representation, orthogonalize
-    responses, state space form for the dynamic model, as well as filter and
-    smoother routines, simulation, and particle sampler.
+    Provides a collection of utility tools for working with tensor autoregressive models,
+    such as moving average representation, orthogonalize responses, state space form for the
+    dynamic model, as well as filter and smoother routines, simulation, and particle
+    sampler.
 
 @author: Quint Wiersma <q.wiersma@vu.nl>
 
@@ -12,27 +12,15 @@ utilities.jl
 =#
 
 """
-    confidence_bounds(
-        model,
-        periods,
-        α,
-        orth,
-        samples=100,
-        burn=100,
-        rng=Xoshiro()
-    ) -> (lower, upper)
+    confidence_bounds(model, periods, α, orth, samples=100, burn=100, rng=Xoshiro())
+    -> (lower, upper)
 
-Compute Monte Carlo `α`% confidence bounds for impulse response functions of the
-tensor autoregressive model given by `model`. The confidence bounds are
-estimated using a Monte Carlo simulation with `samples` and a burn-in period
-`burn`.
+Compute Monte Carlo `α`% confidence bounds for impulse response functions of the tensor
+autoregressive model given by `model`. The confidence bounds are estimated using a Monte
+Carlo simulation with `samples` and a burn-in period `burn`.
 """
-function confidence_bounds(model::AbstractTensorAutoregression,
-                           periods::Integer,
-                           α::Real,
-                           orth::Bool,
-                           samples::Integer = 100,
-                           burn::Integer = 100,
+function confidence_bounds(model::AbstractTensorAutoregression, periods::Integer, α::Real,
+                           orth::Bool, samples::Integer = 100, burn::Integer = 100,
                            rng::AbstractRNG = Xoshiro())
     Ψ = Vector{Array}(undef, samples)
 
@@ -67,8 +55,8 @@ end
 """
     moving_average(model, n) -> Ψ
 
-Moving average, ``MA(∞)``, representation of the tensor autoregressive model
-`model`, computed up to the `n`th term.
+Moving average, ``MA(∞)``, representation of the tensor autoregressive model `model`,
+computed up to the `n`th term.
 """
 function moving_average(model::StaticTensorAutoregression, n::Integer)
     dims = size(coef(model))
@@ -85,7 +73,6 @@ function moving_average(model::StaticTensorAutoregression, n::Integer)
 
     return Ψ
 end
-
 function moving_average(model::DynamicTensorAutoregression, n::Integer)
     dims = size(coef(model))
     R = (length(dims) ÷ 2 + 1):(length(dims) - 1)
@@ -121,8 +108,8 @@ end
 """
     orthogonalize(Ψ, Σ) -> Ψ_orth
 
-Orthogonalize impulse responses `Ψ` using the Cholesky decomposition of
-covariance matrix `Σ`.
+Orthogonalize impulse responses `Ψ` using the Cholesky decomposition of covariance matrix
+`Σ`.
 """
 function orthogonalize(Ψ::AbstractArray, Σ::AbstractMatrix)
     n = ndims(Ψ) - 1
@@ -139,7 +126,6 @@ function orthogonalize(Ψ::AbstractArray, Σ::AbstractMatrix)
 
     return Ψ_orth
 end
-
 function orthogonalize(Ψ::AbstractArray, Σ::AbstractVector)
     # Cholesky decompositions of Σᵢ
     C = [cholesky(Hermitian(Σi)).U for Σi in Σ]
@@ -151,22 +137,15 @@ function orthogonalize(Ψ::AbstractArray, Σ::AbstractVector)
 end
 
 """
-    particle_sampler(
-        model,
-        periods;
-        time=last(size(coef(model))),
-        samples=1000,
-        rng=Xoshiro()
-    ) -> particles
+    particle_sampler(model, periods; time=last(size(coef(model))), samples=1000,
+                     rng=Xoshiro()) -> particles
 
 Forward particle sampler of the filtered state ``αₜ₊ₕ`` for the dynamic tensor
-autoregressive model `model`, with the number of forward periods given by
-`periods` starting from `time` and using random number generator `rng`.
+autoregressive model `model`, with the number of forward periods given by `periods` starting
+from `time` and using random number generator `rng`.
 """
-function particle_sampler(model::DynamicTensorAutoregression,
-                          periods::Integer;
-                          time::Integer = last(size(coef(model))),
-                          samples::Integer = 1000,
+function particle_sampler(model::DynamicTensorAutoregression, periods::Integer;
+                          time::Integer = last(size(coef(model))), samples::Integer = 1000,
                           rng::AbstractRNG = Xoshiro())
     # transition coefficients
     T = dynamics(coef(model))
@@ -196,8 +175,8 @@ end
 """
     collapse(model) -> (A_low, Z_basis)
 
-Low-dimensional collapsing matrices for the dynamic tensor autoregressive model
-`model` following the approach of Jungbacker and Koopman (2015).
+Low-dimensional collapsing matrices for the dynamic tensor autoregressive model `model`
+following the approach of Jungbacker and Koopman (2015).
 """
 function collapse(model::DynamicTensorAutoregression)
     dims = size(data(model))
@@ -230,8 +209,8 @@ end
 """
     state_space(model) -> (y_low, Z_low, H_low, a1, P1)
 
-State space form of the collapsed dynamic tensor autoregressive model `model`
-following the approach of Jungbacker and Koopman (2015).
+State space form of the collapsed dynamic tensor autoregressive model `model` following the
+approach of Jungbacker and Koopman (2015).
 """
 function state_space(model::DynamicTensorAutoregression)
     dims = size(data(model))
@@ -265,9 +244,9 @@ end
 """
     filter(model) -> (a, P, v, F, K)
 
-Collapsed Kalman filter for the dynamic tensor autoregressive model `model`.
-Returns the filtered state `a`, covariance `P`, forecast error `v`, forecast
-error variance `F`, and Kalman gain `K`.
+Collapsed Kalman filter for the dynamic tensor autoregressive model `model`. Returns the
+filtered state `a`, covariance `P`, forecast error `v`, forecast error variance `F`, and
+Kalman gain `K`.
 """
 function filter(model::DynamicTensorAutoregression)
     # collapsed state space system
@@ -309,8 +288,8 @@ end
 """
     smoother(model) -> (α, V, Γ)
 
-Collapsed Kalman smoother for the dynamic tensor autoregressive model `model`.
-Returns the smoothed state `α`, covariance `V`, and autocovariance `Γ`.
+Collapsed Kalman smoother for the dynamic tensor autoregressive model `model`. Returns the
+smoothed state `α`, covariance `V`, and autocovariance `Γ`.
 """
 function smoother(model::DynamicTensorAutoregression)
     # collapsed state space system
@@ -351,16 +330,12 @@ end
 """
     simulate(A, burn, rng) -> (A_sim, A_burn)
 
-Simulate the dynamic loadings from the dynamic Kruskal coefficient tensor `A`
-with a burn-in period of `burn` using the random number generator `rng`.
+Simulate the dynamic loadings from the dynamic Kruskal coefficient tensor `A` with a burn-in
+period of `burn` using the random number generator `rng`.
 """
 function simulate(A::DynamicKruskal, burn::Integer, rng::AbstractRNG)
-    A_burn = DynamicKruskal(similar(loadings(A), size(loadings(A), 1), burn),
-                            intercept(A),
-                            dynamics(A),
-                            cov(A),
-                            factors(A),
-                            rank(A))
+    A_burn = DynamicKruskal(similar(loadings(A), size(loadings(A), 1), burn), intercept(A),
+                            dynamics(A), cov(A), factors(A), rank(A))
     dist = MvNormal(cov(A_burn))
     # burn-in
     for (t, λt) in pairs(eachslice(loadings(A_burn), dims = 2))
@@ -388,8 +363,8 @@ end
 """
     simulate(ε, burn, rng) -> (ε_sim, ε_burn)
 
-Simulate from the tensor error distribution `ε` with a burn-in period of `burn`
-using the random number generator `rng`.
+Simulate from the tensor error distribution `ε` with a burn-in period of `burn` using the
+random number generator `rng`.
 """
 simulate(ε::WhiteNoise, burn::Integer, rng::AbstractRNG) = error("simulating data from white noise error not supported.")
 function simulate(ε::TensorNormal, burn::Integer, rng::AbstractRNG)
@@ -399,8 +374,7 @@ function simulate(ε::TensorNormal, burn::Integer, rng::AbstractRNG)
     # Cholesky decompositions of Σᵢ
     C = [cholesky(Hermitian(Σi)).L for Σi in cov(ε)]
 
-    ε_burn = TensorNormal(similar(resid(ε), dims[1:n]..., burn),
-                          cov(ε))
+    ε_burn = TensorNormal(similar(resid(ε), dims[1:n]..., burn), cov(ε))
     # burn-in
     for εt in eachslice(resid(ε_burn), dims = n + 1)
         # sample independent random normals and use tucker product with Cholesky

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -13,7 +13,7 @@ utilities.jl
 
 """
     confidence_bounds(model, periods, α, orth, samples=100, burn=100, rng=Xoshiro())
-    -> (lower, upper)
+        -> (lower, upper)
 
 Compute Monte Carlo `α`% confidence bounds for impulse response functions of the tensor
 autoregressive model given by `model`. The confidence bounds are estimated using a Monte


### PR DESCRIPTION
Update the coding style to match SciML style. Additionally ensure that TensorAutoregressions ties into the StatsAPI convention system. Change the stopping criteria to one based on likelihood/objective function value improvement. Finally, implement some interface changes, such as removing fixed parameter option.