### PR TITLE
Generalized IRF methods 

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -290,23 +290,13 @@ end
 # methods
 irf(irfs::AbstractIRF) = irfs.Ψ
 irf(irfs::StaticIRF, impulse, response) = @view irf(irfs)[impulse..., response..., :]
-irf(irfs::DynamicIRF, impulse, response) = @view irf(irfs)[impulse..., response..., :, :]
-function irf(irfs::DynamicIRF, impulse, response, time)
-    @view irf(irfs)[impulse..., response..., :, time]
-end
+irf(irfs::DynamicIRF, response) = @view irf(irfs)[response..., :, :]
+irf(irfs::DynamicIRF, response, time) = @view irf(irfs)[response..., :, time]
 lower(irfs::AbstractIRF) = irfs.lower
 lower(irfs::StaticIRF, impulse, response) = @view lower(irfs)[impulse..., response..., :]
-function lower(irfs::DynamicIRF, impulse, response)
-    @view lower(irfs)[impulse..., response..., :, :]
-end
-function lower(irfs::DynamicIRF, impulse, response, time)
-    @view lower(irfs)[impulse..., response..., :, time]
-end
+lower(irfs::DynamicIRF, response) = @view lower(irfs)[response..., :, :]
+lower(irfs::DynamicIRF, response, time) = @view lower(irfs)[response..., :, time]
 upper(irfs::AbstractIRF) = irfs.upper
 upper(irfs::StaticIRF, impulse, response) = @view upper(irfs)[impulse..., response..., :]
-function upper(irfs::DynamicIRF, impulse, response)
-    @view upper(irfs)[impulse..., response..., :, :]
-end
-function upper(irfs::DynamicIRF, impulse, response, time)
-    @view upper(irfs)[impulse..., response..., :, time]
-end
+upper(irfs::DynamicIRF, response) = @view upper(irfs)[response..., :, :]
+upper(irfs::DynamicIRF, response, time) = @view upper(irfs)[response..., :, time]

--- a/src/types.jl
+++ b/src/types.jl
@@ -290,13 +290,13 @@ end
 # methods
 irf(irfs::AbstractIRF) = irfs.Ψ
 irf(irfs::StaticIRF, impulse, response) = @view irf(irfs)[impulse..., response..., :]
-irf(irfs::DynamicIRF, response) = @view irf(irfs)[response..., :, :]
-irf(irfs::DynamicIRF, response, time) = @view irf(irfs)[response..., :, time]
+irf(irfs::DynamicIRF, response) = @view irf(irfs)[response..., :]
+irf(irfs::DynamicIRF, response) = @view irf(irfs)[response..., :]
 lower(irfs::AbstractIRF) = irfs.lower
 lower(irfs::StaticIRF, impulse, response) = @view lower(irfs)[impulse..., response..., :]
-lower(irfs::DynamicIRF, response) = @view lower(irfs)[response..., :, :]
-lower(irfs::DynamicIRF, response, time) = @view lower(irfs)[response..., :, time]
+lower(irfs::DynamicIRF, response) = @view lower(irfs)[response..., :]
+lower(irfs::DynamicIRF, response) = @view lower(irfs)[response..., :]
 upper(irfs::AbstractIRF) = irfs.upper
 upper(irfs::StaticIRF, impulse, response) = @view upper(irfs)[impulse..., response..., :]
-upper(irfs::DynamicIRF, response) = @view upper(irfs)[response..., :, :]
-upper(irfs::DynamicIRF, response, time) = @view upper(irfs)[response..., :, time]
+upper(irfs::DynamicIRF, response) = @view upper(irfs)[response..., :]
+upper(irfs::DynamicIRF, response) = @view upper(irfs)[response..., :]

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -15,13 +15,12 @@ utilities.jl
     confidence_bounds(model, periods, α, orth, samples=100, burn=100, rng=Xoshiro())
         -> (lower, upper)
 
-Compute Monte Carlo `α`% confidence bounds for impulse response functions of the tensor
-autoregressive model given by `model`. The confidence bounds are estimated using a Monte
-Carlo simulation with `samples` and a burn-in period `burn`.
+Compute Monte Carlo `α`% confidence bounds for impulse response functions of the static
+tensor autoregressive model given by `model`. The confidence bounds are estimated using a
+Monte Carlo simulation with `samples` and a burn-in period `burn`.
 """
-#TODO Adjust confidence bounds calculation of IRFs of static model to accomodate generalized IRFs
-function confidence_bounds(model::StaticTensorAutoregression, periods::Integer, α::Real,
-                           orth::Bool, samples::Integer = 100, burn::Integer = 100,
+function confidence_bounds(model::StaticTensorAutoregression, periods::Integer, α::Real;
+                           samples::Integer = 100, burn::Integer = 100,
                            rng::AbstractRNG = Xoshiro())
     Ψ = Vector{Array}(undef, samples)
 
@@ -36,8 +35,8 @@ function confidence_bounds(model::StaticTensorAutoregression, periods::Integer, 
         # moving average representation
         Ψ[s] = moving_average(sim, periods)
 
-        # orthogonalize
-        orth ? Ψ[s] = orthogonalize(Ψ[s], cov(sim)) : nothing
+        # girf
+        Ψ[s] = integrate(Ψ[s], cov(sim))
     end
 
     # quantiles

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -174,7 +174,8 @@ function sampler(model::DynamicTensorAutoregression, samples::Integer, periods::
     # sample paths
     paths = similar(data(model), d..., periods, length(conditional), samples)
     for (t, conditional_paths) in pairs(eachslice(paths, dims = ndims(paths) - 1))
-        path_sampler!(conditional_paths, model, selectdim(particles, ndims(particles), t),
+        path_sampler!(conditional_paths, model,
+                      selectdim(particles, ndims(particles) - 1, t),
                       selectdim(noise, n + 1,
                                 ((t - 1) * samples * periods + 1):(t * samples * periods)),
                       conditional[t])
@@ -198,7 +199,8 @@ function sampler(model::DynamicTensorAutoregression, samples::Integer, periods::
     # sample paths
     paths = similar(data(model), d..., periods, length(conditional), samples)
     for (t, conditional_paths) in pairs(eachslice(paths, dims = ndims(paths) - 1))
-        path_sampler!(conditional_paths, model, selectdim(particles, ndims(particles), t),
+        path_sampler!(conditional_paths, model,
+                      selectdim(particles, ndims(particles) - 1, t),
                       selectdim(noise, n + 1,
                                 ((t - 1) * samples * periods + 1):(t * samples * periods)),
                       conditional[t])


### PR DESCRIPTION
Generalized IRF calculations for tensor autoregressive models. 

- For the static version of the model the confidence bounds method needs to be adjusted.
- For the dynamic version of the model a Monte Carlo estimator is used on the entire model structure.
- As the Monte Carlo estimator for the dynamic model might be computationally demanding it might be necesary to adjust the code to accept only a single shock at a time.